### PR TITLE
[chore] swagger 라이브러리 의존성 추가 수정 #1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 
 	// api doc
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- swagger web MVC 라이브러리로 변경

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)

## 🔀 변경사항
- SpringDoc OpenAPI UI -> SpringDoc OpenAPI Starter WebMVC UI 2.2.0 라이브러리 변경

## 🔗 이슈번호
#1 

---

<details open> <summary>스크린샷 & 비디오 </summary>

- **변경 전 Swagger 라이브러리**

![image](https://github.com/user-attachments/assets/899c063a-3a48-4779-b4b3-aac92844a7b5)

- **현재 Swagger 라이브러리 SpringDoc OpenAPI Starter WebMVC UI 2.2.0**

![image](https://github.com/user-attachments/assets/44774e73-bbcb-4559-8835-cb5ebe287ac6)

</details>
