### PR TITLE
[feat] Querydsl 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# Querydls generate file ignore
+/src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,12 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// dev tool
 	annotationProcessor 'org.projectlombok:lombok'
 	compileOnly 'org.projectlombok:lombok'
@@ -44,6 +50,18 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+}
+
+def generated = 'src/main/generated'
+
+sourceSets { main.java.srcDirs += [generated] }
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+clean {
+	delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/refooding/api/common/config/QuerydslConfig.java
+++ b/src/main/java/refooding/api/common/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package refooding.api.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+
+}


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- Querydsl 의존성 추가 및 QClass 생성 설정
```java
//Querydsl 추가
implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

// QueryDsl 쿼리 타입 생성 (QClass 생성 시 @Entity 탐색)
annotationProcessor "com.querydsl:querydsl apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"

annotationProcessor "jakarta.annotation:jakarta.annotation-api"
annotationProcessor "jakarta.persistence:jakarta.persistence-api"

// QClass 저장할 경로 설정
def generated = 'src/main/generated'

/**
 * sourceSets은 gradle 빌드 스크립트에서 정의한 소스코드와 리소스 디렉토리를 구성하고 관리할 때 사용하는 것으로
 * gradle이 generated 디렉토리를 프로젝트의 소스 코드로 인식할 수 있도록 설정하는 것
 * 따라서, 컴파일 과정에서 generated 디렉토리 내의 Java 파일들을 포함시킨다
 */
sourceSets { main.java.srcDirs += [generated] }

/**
 * 모든 JavaCompile 태스크가 발생할 때 즉, JavaCompile 작업이 일어날 때
 * QueryDSL의 QClass 파일 생성 디렉토리 위치를 지정할 때 사용
 */
tasks.withType(JavaCompile).configureEach {
	options.getGeneratedSourceOutputDirectory().set(file(generated))
}

// gradle clean 명령어 실행시 QClass Directory 삭제하도록 설정
clean {
	delete file(generated)
}
```

- 전역에서 JPAQueryFactory 사용을 위해 설정 [[feat] Querydsl config 파일 추가](https://github.com/HomeChefHub/refooding-be/commit/1bb2ce71797cd12746c2fd416663c5e89f6b8b09)

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항


## 🔗 이슈번호
#28 

---

<details open> <summary>스크린샷 & 비디오 </summary>

- ✨ QClass를 생성하기 위해서는 **gradle에서 1.bulid/clean 2.other/complieJava를 클릭**하면 src/main/generated 파일에 QClass가 생성됩니다!

![스크린샷 2024-07-23 오후 12 24 25](https://github.com/user-attachments/assets/341dc20d-a4fc-42e3-ad70-6d1be6498e9d)

![스크린샷 2024-07-23 오후 12 25 44](https://github.com/user-attachments/assets/cda4ec4e-d5c2-45ab-99fa-f72bba9afc1e)

![image](https://github.com/user-attachments/assets/defaf27e-de10-4362-96cf-4c5999fce59d)

</details>
