### PR TITLE
[feat] 테스트용 멤버 엔티티 추가 및 CRUD API 구현 #26

### DIFF
--- a/src/main/java/refooding/api/domain/member/controller/MemberController.java
+++ b/src/main/java/refooding/api/domain/member/controller/MemberController.java
@@ -1,0 +1,140 @@
+package refooding.api.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import refooding.api.domain.member.dto.MemberRequest;
+import refooding.api.domain.member.dto.MemberResponse;
+import refooding.api.domain.member.entity.Member;
+import refooding.api.domain.member.service.MemberService;
+import refooding.api.domain.recipe.dto.RecipeResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Tag(name = "테스트용 멤버 CRUD API")
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    @Operation(
+            summary = "회원 가입",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원 가입 성공",
+                            content = @Content(schema = @Schema(implementation = MemberResponse.class))
+                    )
+            }
+    )
+    public ResponseEntity<Long> join(@RequestBody MemberRequest memberRequest) {
+        Long memberId = memberService.join(memberRequest);
+        return ResponseEntity.ok(memberId);
+    }
+
+
+    @GetMapping
+    @Operation(
+            summary = "전체 회원 목록 조회 - 탈퇴한 회원 제외",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "탈퇴한 회원 제외 전체 회원 목록 조회 성공",
+                            content = @Content(schema = @Schema(implementation = MemberResponse.class))
+                    )
+            }
+    )
+    public ResponseEntity<List<MemberResponse>> findAllMembers() {
+        List<MemberResponse> response = memberService.findMembers().stream()
+                .map(member -> MemberResponse.builder()
+                        .id(member.getId())
+                        .name(member.getName())
+                        .build())
+                .toList();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/all")
+    @Operation(
+            summary = "전체 회원 목록 조회 - 탈퇴한 회원 포함",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "탈퇴한 회원 포함 전체 회원 목록 조회 성공",
+                            content = @Content(schema = @Schema(implementation = MemberResponse.class))
+                    )
+            }
+    )
+    public ResponseEntity<List<MemberResponse>> findAllMembersIncludingDeleted() {
+        List<MemberResponse> members = memberService.findMembersIncludingDeleted().stream()
+                .map(member -> MemberResponse.builder()
+                        .id(member.getId())
+                        .name(member.getName())
+                        .build())
+                .toList();
+        return ResponseEntity.ok(members);
+    }
+
+    @GetMapping("/{memberId}")
+    @Operation(
+            summary = "회원 상세 조회",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원 상세 조회 성공",
+                            content = @Content(schema = @Schema(implementation = MemberResponse.class))
+                    )
+            }
+    )
+    public ResponseEntity<MemberResponse> findOne(@PathVariable Long memberId) {
+        MemberResponse response = memberService.findOne(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{memberId}")
+    @Operation(
+            summary = "회원 이름 수정",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원 이름 수정 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "회원이 존재하지 않음"
+                    )
+            }
+    )
+    public ResponseEntity<Void> updateMemberName(@PathVariable Long memberId, @RequestBody MemberRequest memberRequest) {
+        memberService.updateMemberName(memberId, memberRequest.getName());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{memberId}")
+    @Operation(
+            summary = "회원 탈퇴",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "회원 탈퇴 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "회원이 존재하지 않음"
+                    )
+            }
+    )
+    public ResponseEntity<Void> deleteMember(@PathVariable Long memberId) {
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/refooding/api/domain/member/dto/MemberRequest.java
+++ b/src/main/java/refooding/api/domain/member/dto/MemberRequest.java
@@ -1,0 +1,14 @@
+package refooding.api.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class MemberRequest {
+    private String name;
+}

--- a/src/main/java/refooding/api/domain/member/dto/MemberResponse.java
+++ b/src/main/java/refooding/api/domain/member/dto/MemberResponse.java
@@ -1,0 +1,13 @@
+package refooding.api.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class MemberResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/refooding/api/domain/member/entity/Member.java
+++ b/src/main/java/refooding/api/domain/member/entity/Member.java
@@ -1,0 +1,39 @@
+package refooding.api.domain.member.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import refooding.api.common.domain.BaseTimeEntity;
+import refooding.api.domain.exchange.entity.ExchangeStatus;
+import refooding.api.domain.exchange.entity.Region;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseTimeEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Builder
+    public Member(String name) {
+        this.name = name;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void delete() {
+        this.deletedDate = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/refooding/api/domain/member/repository/MemberRepository.java
+++ b/src/main/java/refooding/api/domain/member/repository/MemberRepository.java
@@ -1,0 +1,20 @@
+package refooding.api.domain.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import refooding.api.domain.member.entity.Member;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    // 삭제되지 않은 모든 회원 조회
+    List<Member> findAllByDeletedDateIsNull();
+
+    // 삭제되지 않은 회원 ID로 조회
+    Optional<Member> findByIdAndDeletedDateIsNull(Long id);
+
+    // 삭제되지 않은 회원 중에서 이름으로 검색
+    Optional<Member> findByNameAndDeletedDateIsNull(String name);
+
+}

--- a/src/main/java/refooding/api/domain/member/service/MemberService.java
+++ b/src/main/java/refooding/api/domain/member/service/MemberService.java
@@ -1,0 +1,95 @@
+package refooding.api.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import refooding.api.domain.member.dto.MemberRequest;
+import refooding.api.domain.member.dto.MemberResponse;
+import refooding.api.domain.member.entity.Member;
+import refooding.api.domain.member.repository.MemberRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    /**
+     * 회원 가입
+     */
+    @Transactional
+    public Long join(MemberRequest memberRequest) {
+        Member member = Member.builder().name(memberRequest.getName()).build();
+        validateDuplicateMember(member); // 이름이 같은 회원은 회원 가입 불가
+        memberRepository.save(member);
+        return member.getId();
+    }
+
+    private void validateDuplicateMember(Member member) {
+        memberRepository.findByNameAndDeletedDateIsNull(member.getName())
+                .ifPresent(m -> {
+                    throw new IllegalStateException("이름이 같은 회원은 회원 가입할 수 없습니다.");
+                });
+    }
+
+    /**
+     * 회원 목록 조회 - 탈퇴한 회원도 조회
+     */
+    public List<MemberResponse> findMembersIncludingDeleted() {
+        return memberRepository.findAll().stream()
+                .map(this::convertToDto)
+                .toList();
+    }
+
+    /**
+     * 회원 목록 조회 - 탈퇴하지 않는 회원만 조회
+     */
+    public List<MemberResponse> findMembers() {
+        return memberRepository.findAllByDeletedDateIsNull().stream()
+                .map(this::convertToDto)
+                .toList();
+    }
+
+    /**
+     * 회원 상세 조회
+     */
+    public MemberResponse findOne(Long memberId){
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(memberId)
+                .orElseThrow(() -> new IllegalStateException("id에 해당하는 회원이 없습니다."));
+        return convertToDto(member);
+    }
+
+    /**
+     * 회원 이름 수정
+     */
+    @Transactional
+    public void updateMemberName(Long memberId, String newName) {
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(memberId)
+                .orElseThrow(() -> new IllegalStateException("id에 해당하는 회원이 없습니다."));
+        member.updateName(newName);
+    }
+
+
+    /**
+     * 회원 탈퇴
+     */
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findByIdAndDeletedDateIsNull(memberId)
+                .orElseThrow(() -> new IllegalStateException("id에 해당하는 회원이 없습니다."));
+        member.delete();
+    }
+
+    private MemberResponse convertToDto(Member member) {
+        return MemberResponse.builder()
+                .id(member.getId())
+                .name(member.getName())
+                .build();
+    }
+
+
+}


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
 Member 엔티티 추가
 Member CRUD API 구현

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항
Member 엔티티는 id, name 필드만 보유


## 🔗 이슈번호
#26 

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
