### PR TITLE
[feat] 식재료 교환 목록 조회 API 구현

### DIFF
--- a/src/main/java/refooding/api/common/qeurydsl/QuerydslRepositoryUtils.java
+++ b/src/main/java/refooding/api/common/qeurydsl/QuerydslRepositoryUtils.java
@@ -1,0 +1,30 @@
+package refooding.api.common.qeurydsl;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class QuerydslRepositoryUtils {
+
+    private static final int ADDITIONAL_FETCH_COUNT = 1;
+
+    public static <T> Slice<T> fetchSlice(JPAQuery<T> query, Pageable pageable) {
+
+        List<T> content = query
+                .limit(pageable.getPageSize() + ADDITIONAL_FETCH_COUNT)
+                .fetch();
+
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            return new SliceImpl<>(content, pageable, true);
+        }
+
+        return new SliceImpl<>(content, pageable, false);
+    }
+
+}

--- a/src/main/java/refooding/api/domain/exchange/controller/ExchangeController.java
+++ b/src/main/java/refooding/api/domain/exchange/controller/ExchangeController.java
@@ -1,12 +1,16 @@
 package refooding.api.domain.exchange.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
 import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
 import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;
+import refooding.api.domain.exchange.dto.response.ExchangeResponse;
 import refooding.api.domain.exchange.dto.response.RegionResponse;
+import refooding.api.domain.exchange.entity.ExchangeStatus;
 import refooding.api.domain.exchange.service.ExchangeService;
 import refooding.api.domain.exchange.service.RegionService;
 
@@ -21,12 +25,27 @@ public class ExchangeController implements ExchangeControllerOpenApi{
     private final ExchangeService exchangeService;
     private final RegionService regionService;
 
+    @Override
+    @GetMapping
+    public ResponseEntity<Slice<ExchangeResponse>> getExchanges(
+            @RequestParam(required = false)  String keyword,
+            @RequestParam(required = false)  Long regionId,
+            @RequestParam(required = false)  ExchangeStatus status,
+            @RequestParam(required = false, defaultValue = "10") int size,
+            @RequestParam(required = false) Long lastExchangeId
+            ) {
+
+        Slice<ExchangeResponse> response = exchangeService.findExchanges(keyword, status, regionId, lastExchangeId, PageRequest.ofSize(size));
+        return ResponseEntity.ok(response);
+    }
+    @Override
     @GetMapping("/{exchangeId}")
     public ResponseEntity<ExchangeDetailResponse> getExchangeById(@PathVariable Long exchangeId) {
         ExchangeDetailResponse response = exchangeService.getExchangeById(exchangeId);
         return ResponseEntity.ok(response);
     }
 
+    @Override
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody ExchangeCreateRequest request) {
         // TODO : 회원 추가
@@ -34,18 +53,21 @@ public class ExchangeController implements ExchangeControllerOpenApi{
         return ResponseEntity.created(URI.create("/api/v1/exchanges/" + exchangeId)).build();
     }
 
+    @Override
     @PatchMapping("/{exchangeId}")
     public ResponseEntity<Void> update(@PathVariable Long exchangeId, @RequestBody ExchangeUpdateRequest request){
         exchangeService.update(exchangeId, request);
         return ResponseEntity.ok().build();
     }
 
+    @Override
     @DeleteMapping("/{exchangeId}")
     public ResponseEntity<Void> delete(@PathVariable Long exchangeId) {
         exchangeService.delete(exchangeId);
         return ResponseEntity.noContent().build();
     }
 
+    @Override
     @GetMapping("/regions")
     public ResponseEntity<List<RegionResponse>> regions() {
         List<RegionResponse> response = regionService.getRegionsWithChildren();

--- a/src/main/java/refooding/api/domain/exchange/controller/ExchangeController.java
+++ b/src/main/java/refooding/api/domain/exchange/controller/ExchangeController.java
@@ -1,10 +1,5 @@
 package refooding.api.domain.exchange.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,40 +13,21 @@ import refooding.api.domain.exchange.service.RegionService;
 import java.net.URI;
 import java.util.List;
 
-@Tag(name = "식재료 교환 API")
 @RestController
 @RequestMapping("/exchanges")
 @RequiredArgsConstructor
-public class ExchangeController {
+public class ExchangeController implements ExchangeControllerOpenApi{
 
     private final ExchangeService exchangeService;
     private final RegionService regionService;
 
     @GetMapping("/{exchangeId}")
-    @Operation(
-            summary = "식재료 교환 상세 조회",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "식재료 교환 상세 조회 성공"
-                    )
-            }
-    )
     public ResponseEntity<ExchangeDetailResponse> getExchangeById(@PathVariable Long exchangeId) {
         ExchangeDetailResponse response = exchangeService.getExchangeById(exchangeId);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping
-    @Operation(
-            summary = "식재료 교환글 등록",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "201",
-                            description = "식재료 교환글 등록 성공"
-                    )
-            }
-    )
     public ResponseEntity<Void> create(@RequestBody ExchangeCreateRequest request) {
         // TODO : 회원 추가
         Long exchangeId = exchangeService.create(request);
@@ -59,46 +35,18 @@ public class ExchangeController {
     }
 
     @PatchMapping("/{exchangeId}")
-    @Operation(
-            summary = "식재료 교환글 수정",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "식재료 교환글 수정 성공"
-                    )
-            }
-    )
     public ResponseEntity<Void> update(@PathVariable Long exchangeId, @RequestBody ExchangeUpdateRequest request){
         exchangeService.update(exchangeId, request);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{exchangeId}")
-    @Operation(
-            summary = "식재료 교환글 삭제",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "204",
-                            description = "식재료 교환글 삭제 성공"
-                    )
-            }
-    )
     public ResponseEntity<Void> delete(@PathVariable Long exchangeId) {
         exchangeService.delete(exchangeId);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/regions")
-    @Operation(
-            summary = "식재료 교환 지역 목록 조회",
-            responses = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "지역 목록 조회 성공",
-                            content = @Content(schema = @Schema(implementation = RegionResponse.class))
-                    )
-            }
-    )
     public ResponseEntity<List<RegionResponse>> regions() {
         List<RegionResponse> response = regionService.getRegionsWithChildren();
         return ResponseEntity.ok(response);

--- a/src/main/java/refooding/api/domain/exchange/controller/ExchangeControllerOpenApi.java
+++ b/src/main/java/refooding/api/domain/exchange/controller/ExchangeControllerOpenApi.java
@@ -1,0 +1,92 @@
+package refooding.api.domain.exchange.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
+import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
+import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;
+import refooding.api.domain.exchange.dto.response.RegionResponse;
+
+import java.util.List;
+
+@Tag(name = "식재료 교환 API")
+public interface ExchangeControllerOpenApi {
+
+    @Operation(
+            summary = "식재료 교환 상세 조회",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "식재료 교환 상세 조회 성공"
+                    )
+            }
+    )
+    @Parameter(
+            name = "exchangeId",
+            description = "게시글 아이디",
+            required = true
+    )
+    ResponseEntity<ExchangeDetailResponse> getExchangeById(@PathVariable Long exchangeId);
+
+    @Operation(
+            summary = "식재료 교환글 등록",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "식재료 교환글 등록 성공"
+                    )
+            }
+    )
+    ResponseEntity<Void> create(@RequestBody ExchangeCreateRequest request);
+
+    @Operation(
+            summary = "식재료 교환글 수정",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "식재료 교환글 수정 성공"
+                    )
+            }
+    )
+    @Parameter(
+            name = "exchangeId",
+            description = "게시글 아이디",
+            required = true
+    )
+    ResponseEntity<Void> update(@PathVariable Long exchangeId, @RequestBody ExchangeUpdateRequest request);
+
+    @Operation(
+            summary = "식재료 교환글 삭제",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "식재료 교환글 삭제 성공"
+                    )
+            }
+    )
+    @Parameter(
+            name = "exchangeId",
+            description = "게시글 아이디",
+            required = true
+    )
+    ResponseEntity<Void> delete(@PathVariable Long exchangeId);
+
+    @Operation(
+            summary = "식재료 교환 지역 목록 조회",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "지역 목록 조회 성공",
+                            content = @Content(schema = @Schema(implementation = RegionResponse.class))
+                    )
+            }
+    )
+    ResponseEntity<List<RegionResponse>> regions();
+}

--- a/src/main/java/refooding/api/domain/exchange/controller/ExchangeControllerOpenApi.java
+++ b/src/main/java/refooding/api/domain/exchange/controller/ExchangeControllerOpenApi.java
@@ -2,22 +2,65 @@ package refooding.api.domain.exchange.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
 import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
 import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
 import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;
+import refooding.api.domain.exchange.dto.response.ExchangeResponse;
 import refooding.api.domain.exchange.dto.response.RegionResponse;
+import refooding.api.domain.exchange.entity.ExchangeStatus;
 
 import java.util.List;
 
 @Tag(name = "식재료 교환 API")
 public interface ExchangeControllerOpenApi {
+
+    @Operation(
+            summary = "식재료 교환 목록 조회",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "식재료 교환 목록 조회 성공"
+                    )
+            }
+    )
+    @Parameters(
+            value = {
+                    @Parameter(
+                            name = "keyword",
+                            description = "검색어"
+                    ),
+                    @Parameter(
+                            name = "regionId",
+                            description = "지역 아이디"
+                    ),
+                    @Parameter(
+                            name = "status",
+                            description = "식재료 교환 상태"
+                    ),
+                    @Parameter(
+                            name = "size",
+                            description = "요청 컨텐츠 수(0개 이상~50개 이하)"
+                    ),
+                    @Parameter(
+                            name = "lastExchangeId",
+                            description = "이전 요청 목록의 마지막 컨텐츠 아이디"
+                    ),
+            }
+    )
+    ResponseEntity<Slice<ExchangeResponse>> getExchanges(
+            String keyword,
+            Long regionId,
+            ExchangeStatus status,
+            int size,
+            Long lastExchangeId
+    );
 
     @Operation(
             summary = "식재료 교환 상세 조회",
@@ -33,7 +76,7 @@ public interface ExchangeControllerOpenApi {
             description = "게시글 아이디",
             required = true
     )
-    ResponseEntity<ExchangeDetailResponse> getExchangeById(@PathVariable Long exchangeId);
+    ResponseEntity<ExchangeDetailResponse> getExchangeById(Long exchangeId);
 
     @Operation(
             summary = "식재료 교환글 등록",
@@ -44,7 +87,7 @@ public interface ExchangeControllerOpenApi {
                     )
             }
     )
-    ResponseEntity<Void> create(@RequestBody ExchangeCreateRequest request);
+    ResponseEntity<Void> create(ExchangeCreateRequest request);
 
     @Operation(
             summary = "식재료 교환글 수정",
@@ -60,7 +103,7 @@ public interface ExchangeControllerOpenApi {
             description = "게시글 아이디",
             required = true
     )
-    ResponseEntity<Void> update(@PathVariable Long exchangeId, @RequestBody ExchangeUpdateRequest request);
+    ResponseEntity<Void> update(Long exchangeId, ExchangeUpdateRequest request);
 
     @Operation(
             summary = "식재료 교환글 삭제",
@@ -76,7 +119,7 @@ public interface ExchangeControllerOpenApi {
             description = "게시글 아이디",
             required = true
     )
-    ResponseEntity<Void> delete(@PathVariable Long exchangeId);
+    ResponseEntity<Void> delete(Long exchangeId);
 
     @Operation(
             summary = "식재료 교환 지역 목록 조회",

--- a/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeResponse.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeResponse.java
@@ -1,0 +1,21 @@
+package refooding.api.domain.exchange.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import refooding.api.domain.exchange.entity.ExchangeStatus;
+
+import java.time.LocalDateTime;
+
+public record ExchangeResponse(
+        Long exchangeId,
+        String title,
+        String region,
+        String childRegion,
+        ExchangeStatus status,
+        LocalDateTime createDate
+        // TODO : 이미지
+        // TODO : 회원
+) {
+    @QueryProjection
+    public ExchangeResponse {
+    }
+}

--- a/src/main/java/refooding/api/domain/exchange/dto/response/RegionResponse.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/response/RegionResponse.java
@@ -13,18 +13,18 @@ public record RegionResponse(
         @Schema(description = "해당 지역에 대한 하위 지역 목록")
         List<ChildRegion> childRegions) {
 
-    public static RegionResponse from(Region region) {
+    public static RegionResponse of(Region region) {
         return new RegionResponse(
                 region.getId(),
                 region.getName(),
                 region.getChildren().stream()
-                        .map(ChildRegion::from)
+                        .map(ChildRegion::of)
                         .toList()
         );
     }
 
     public record ChildRegion(Long id, String name) {
-        public static ChildRegion from(Region region) {
+        public static ChildRegion of(Region region) {
             return new ChildRegion(region.getId(), region.getName());
         }
     }

--- a/src/main/java/refooding/api/domain/exchange/dto/response/RegionResponse.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/response/RegionResponse.java
@@ -2,7 +2,6 @@ package refooding.api.domain.exchange.dto.response;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
 import refooding.api.domain.exchange.entity.Region;
 
 import java.util.List;
@@ -23,7 +22,7 @@ public record RegionResponse(
         );
     }
 
-    public record ChildRegion(Long id, String name) {
+    private record ChildRegion(Long id, String name) {
         public static ChildRegion of(Region region) {
             return new ChildRegion(region.getId(), region.getName());
         }

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepository.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepository.java
@@ -1,0 +1,9 @@
+package refooding.api.domain.exchange.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import refooding.api.domain.exchange.dto.response.ExchangeResponse;
+
+public interface ExchangeCustomRepository {
+    Slice<ExchangeResponse> findExchangeByCondition(ExchangeSearchCondition request, Pageable pageable);
+}

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepositoryImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepositoryImpl.java
@@ -1,0 +1,73 @@
+package refooding.api.domain.exchange.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.util.StringUtils;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+import refooding.api.common.qeurydsl.QuerydslRepositoryUtils;
+import refooding.api.domain.exchange.dto.response.ExchangeResponse;
+import refooding.api.domain.exchange.dto.response.QExchangeResponse;
+import refooding.api.domain.exchange.entity.ExchangeStatus;
+import refooding.api.domain.exchange.entity.QRegion;
+
+import static refooding.api.domain.exchange.entity.QExchange.exchange;
+import static refooding.api.domain.exchange.entity.QRegion.region;
+
+@Repository
+@RequiredArgsConstructor
+public class ExchangeCustomRepositoryImpl implements ExchangeCustomRepository{
+
+    private final JPAQueryFactory japQueryFactory;
+
+    @Override
+    public Slice<ExchangeResponse> findExchangeByCondition(ExchangeSearchCondition condition, Pageable pageable) {
+
+        QRegion parentRegion = new QRegion("parent");
+
+        JPAQuery<ExchangeResponse> content = japQueryFactory
+                .select(
+                        new QExchangeResponse(
+                                exchange.id,
+                                exchange.title,
+                                parentRegion.name,
+                                region.name,
+                                exchange.status,
+                                exchange.createdDate
+                        )
+                )
+                .from(exchange)
+                .leftJoin(exchange.region, region)
+                .leftJoin(parentRegion).on(parentRegion.id.eq(region.parent.id))
+                .where(
+                        keywordContains(condition.keyword()),
+                        statusEq(condition.status()),
+                        regionEq(condition.regionId()),
+                        cursorCondition(condition.lastExchangeId())
+                )
+                .orderBy(exchange.id.desc());
+
+        return QuerydslRepositoryUtils.fetchSlice(content, pageable);
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        return StringUtils.isNullOrEmpty(keyword) ? null : exchange.title.contains(keyword);
+    }
+
+    private BooleanExpression statusEq(ExchangeStatus status) {
+        return status != null ? exchange.status.eq(status) : null;
+    }
+
+    private BooleanExpression regionEq(Long regionId) {
+        return regionId != null ? exchange.region.id.eq(regionId) : null;
+    }
+
+    private BooleanExpression cursorCondition(Long lastExchangeId){
+        return lastExchangeId == null ? null : exchange.id.lt(lastExchangeId);
+    }
+
+
+}

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeRepository.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeRepository.java
@@ -6,12 +6,11 @@ import refooding.api.domain.exchange.entity.Exchange;
 
 import java.util.Optional;
 
-public interface ExchangeRepository extends JpaRepository<Exchange, Long> {
+public interface ExchangeRepository extends JpaRepository<Exchange, Long>, ExchangeCustomRepository {
 
     @Query("select e from Exchange e " +
             "join fetch e.region r " +
             "join fetch r.parent pr " +
             "where e.id = :exchangeId and e.deletedDate is null")
     Optional<Exchange> findExchangeById(Long exchangeId);
-
 }

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeSearchCondition.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeSearchCondition.java
@@ -1,0 +1,11 @@
+package refooding.api.domain.exchange.repository;
+
+import refooding.api.domain.exchange.entity.ExchangeStatus;
+
+public record ExchangeSearchCondition(
+        String keyword,
+        ExchangeStatus status,
+        Long regionId,
+        Long lastExchangeId
+) {
+}

--- a/src/main/java/refooding/api/domain/exchange/service/ExchangeService.java
+++ b/src/main/java/refooding/api/domain/exchange/service/ExchangeService.java
@@ -1,10 +1,16 @@
 package refooding.api.domain.exchange.service;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
 import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
 import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;
+import refooding.api.domain.exchange.dto.response.ExchangeResponse;
+import refooding.api.domain.exchange.entity.ExchangeStatus;
 
 public interface ExchangeService {
+
+    Slice<ExchangeResponse> findExchanges(String keyword, ExchangeStatus status, Long regionId, Long lastExchangeId, Pageable pageable);
 
     Long create(ExchangeCreateRequest request);
 

--- a/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
@@ -1,14 +1,19 @@
 package refooding.api.domain.exchange.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
 import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
 import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;
+import refooding.api.domain.exchange.dto.response.ExchangeResponse;
 import refooding.api.domain.exchange.entity.Exchange;
+import refooding.api.domain.exchange.entity.ExchangeStatus;
 import refooding.api.domain.exchange.entity.Region;
 import refooding.api.domain.exchange.repository.ExchangeRepository;
+import refooding.api.domain.exchange.repository.ExchangeSearchCondition;
 import refooding.api.domain.exchange.repository.RegionRepository;
 
 @Service
@@ -18,6 +23,14 @@ public class ExchangeServiceImpl implements ExchangeService{
 
     private final ExchangeRepository exchangeRepository;
     private final RegionRepository regionRepository;
+
+    @Override
+    public Slice<ExchangeResponse> findExchanges(String keyword, ExchangeStatus status, Long regionId, Long lastExchangeId, Pageable pageable) {
+        return exchangeRepository.findExchangeByCondition(
+                new ExchangeSearchCondition(keyword, status, regionId, lastExchangeId),
+                pageable
+        );
+    }
 
     @Override
     @Transactional

--- a/src/main/java/refooding/api/domain/exchange/service/RegionService.java
+++ b/src/main/java/refooding/api/domain/exchange/service/RegionService.java
@@ -20,7 +20,7 @@ public class RegionService {
         List<Region> regions = regionRepository.findByParentIsNull();
         return regions
                 .stream()
-                .map(RegionResponse::from)
+                .map(RegionResponse::of)
                 .toList();
     }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -31,17 +31,12 @@ spring:
 
 # swagger
 springdoc:
-  api-docs:
-    path: /api-docs # API 문서 생성 경로
   swagger-ui:
     path: /index.html # Swagger-ui 경로
-    groups-order: asc
     tags-sorter: alpha
     operations-sorter: alpha
+    doc-expansion : none
     display-request-duration: true
-  cache:
-    disabled: true
-  override-with-generic-response: false
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
 

--- a/src/main/resources/exchange-data.sql
+++ b/src/main/resources/exchange-data.sql
@@ -1,3 +1,4 @@
+-- 지역
 INSERT INTO Region (name) VALUES ('서울');
 INSERT INTO Region (name) VALUES ('경기');
 INSERT INTO Region (name) VALUES ('인천');
@@ -278,3 +279,33 @@ INSERT INTO Region (name, parent_id) VALUES ('화순군', 15);
 -- 제주도 (id: 16)
 INSERT INTO Region (name, parent_id) VALUES ('서귀포시', 16);
 INSERT INTO Region (name, parent_id) VALUES ('제주시', 16);
+
+-- 식재료 교환 등록
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('당근 나눔합니다', '당근 나눠드려요', 'ACTIVE', 17, '2024-07-24 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('오이 나눔합니다', '오이 나눠드려요', 'TRADED', 19, '2024-07-24 14:15:49.431', '2024-07-24 14:15:49.431');
+
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('수박 나눔합니다', '수박 나눠드려요', 'TRADED', 17, '2024-07-25 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('호박 나눔합니다', '호박 나눠드려요', 'ACTIVE', 20, '2024-07-25 14:15:49.431', '2024-07-24 14:15:49.431');
+
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('당근 공동구매 하실분?', '강남구 당근 공구 구해요', 'TRADED', 17, '2024-07-26 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('파 나눔합니다', '파가 많아서 나눠드려요', 'ACTIVE', 20, '2024-07-26 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('자몽 팔아요', '자몽 한박스 팔아요', 'TRADED', 17, '2024-07-26 14:15:49.431', '2024-07-24 14:15:49.431');
+
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('상추 나눔합니다', '상추 나눠드려요', 'ACTIVE', 19, '2024-07-27 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('당근 팔아요!', '당근 5개에 2000원에 팔아요', 'ACTIVE', 17, '2024-07-27 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('멜론 공구 구합니다', '멜론 공구합시다', 'TRADED', 23, '2024-07-27 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('시금치 나눔합니다', '시금치 나눠드려요', 'ACTIVE', 17, '2024-07-27 14:15:49.431', '2024-07-24 14:15:49.431');
+
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('당근당근 나눔합니다', '당근당근 나눠드려요', 'ACTIVE', 17, '2024-07-28 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('당근당근 팔아요', '당근당근 팔아요', 'ACTIVE', 51, '2024-07-28 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('당근이 필요해요', '당근이 필요해요', 'ACTIVE', 55, '2024-07-28 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('제주도에서 당근이 올라왔어요', '당근 좋아요', 'TRADED', 60, '2024-07-28 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('초당당근 나눔합니다', '초당당근 나눠드려요', 'ACTIVE', 51, '2024-07-28 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('불고기에 당근 넣으시나요? 나눔합니다', '불고기에 당근 넣으시나요? 나눠드려요', 'TRADED', 17, '2024-07-28 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('잡채에 당근 넣으시나요? 나눔합니다', '잡채에 당근 넣으시나요? 나눠드려요', 'TRADED', 60, '2024-07-28 14:15:49.431', '2024-07-24 14:15:49.431');
+
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('카레에 당근 넣으시나요? 나눔합니다', '카레에 당근 넣으시나요? 나눠드려요', 'ACTIVE', 17, '2024-07-29 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('오징어볶음에 당근 넣으시나요? 나눔합니다', '오징어볶음에 당근 넣으시나요? 나눠드려요', 'TRADED', 60, '2024-07-29 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('제육볶음에 당근 넣으시나요? 나눔합니다', '제육볶음에 당근 넣으시나요? 나눠드려요', 'ACTIVE', 248, '2024-07-29 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('수제비에 당근 넣으시나요? 나눔합니다', '수제비에 당근 넣으시나요? 나눠드려요', 'TRADED', 248, '2024-07-29 14:15:49.431', '2024-07-24 14:15:49.431');
+INSERT INTO Exchange (title, content, status, region_id, created_date, modified_date) VALUES ('칼국수에 당근 넣으시나요? 나눔합니다', '칼국수에 당근 넣으시나요? 나눠드려요', 'TRADED', 17, '2024-07-29 14:15:49.431', '2024-07-24 14:15:49.431');


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- 식재료 교환 목록 조회 API 구현
- Swagger Controller -> ExchangeControllerOpenApi Interface 분리
  - ✨ Controller가 어노테이션으로 너무 지저분해서 Controller가 Interface를 구현하는 방식으로 변경했어요.

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항
- Swagger Controller -> ExchangeControllerOpenApi Interface 분리

## 🔗 이슈번호
#23 

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
