### PR TITLE
[feat] CustomException, ExceptionCode, GlobalExceptionHandler 추가

### DIFF
--- a/src/main/java/refooding/api/common/exception/CustomException.java
+++ b/src/main/java/refooding/api/common/exception/CustomException.java
@@ -1,0 +1,15 @@
+package refooding.api.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+
+    private final ExceptionCode exceptionCode;
+
+    public CustomException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+
+}

--- a/src/main/java/refooding/api/common/exception/ExceptionCode.java
+++ b/src/main/java/refooding/api/common/exception/ExceptionCode.java
@@ -7,14 +7,16 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionCode {
 
     // 404
-    NOT_FOUND_EXCHANGE(HttpStatus.NOT_FOUND, "존재하지 않는 교환글 입니다"),
+    NOT_FOUND_EXCHANGE(HttpStatus.NOT_FOUND, "존재하지 않는 식재료 교환글 입니다"),
     NOT_FOUND_REGION(HttpStatus.NOT_FOUND, "존재하지 않는 지역입니다"),
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다"),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다"),
 
     // 500
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다"),
+    TEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "테스트 에러입니");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/refooding/api/common/exception/ExceptionCode.java
+++ b/src/main/java/refooding/api/common/exception/ExceptionCode.java
@@ -1,0 +1,27 @@
+package refooding.api.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ExceptionCode {
+
+    // 404
+    NOT_FOUND_EXCHANGE(HttpStatus.NOT_FOUND, "존재하지 않는 교환글 입니다"),
+    NOT_FOUND_REGION(HttpStatus.NOT_FOUND, "존재하지 않는 지역입니다"),
+
+    // 401
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다"),
+
+    // 500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ExceptionCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/refooding/api/common/exception/ExceptionResponse.java
+++ b/src/main/java/refooding/api/common/exception/ExceptionResponse.java
@@ -9,4 +9,8 @@ public record ExceptionResponse(
     public static ExceptionResponse of(ExceptionCode exceptionCode) {
         return new ExceptionResponse(exceptionCode.getStatus(), exceptionCode.getMessage());
     }
+
+    public static ExceptionResponse of(HttpStatus status, String message) {
+        return new ExceptionResponse(status, message);
+    }
 }

--- a/src/main/java/refooding/api/common/exception/ExceptionResponse.java
+++ b/src/main/java/refooding/api/common/exception/ExceptionResponse.java
@@ -1,0 +1,12 @@
+package refooding.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public record ExceptionResponse(
+        HttpStatus status,
+        String message
+) {
+    public static ExceptionResponse of(ExceptionCode exceptionCode) {
+        return new ExceptionResponse(exceptionCode.getStatus(), exceptionCode.getMessage());
+    }
+}

--- a/src/main/java/refooding/api/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/refooding/api/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,82 @@
+package refooding.api.common.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import refooding.api.common.exception.CustomException;
+import refooding.api.common.exception.ExceptionResponse;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler{
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ExceptionResponse> handleCustomException(CustomException e) {
+        log.warn("[CustomException] {}", e.getMessage(), e);
+
+        ExceptionResponse response = ExceptionResponse.of(e.getExceptionCode());
+
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+    /**
+     * 해당 api(url)에 지원하지 않는 http 메서드 요청시 발생하는 예외
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e
+    ) {
+        log.warn("[HttpRequestMethodNotSupportedException] {}", e.getMessage(), e);
+
+        ExceptionResponse response = ExceptionResponse.of(METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다");
+
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+    /**
+     * HTTP Body 파싱이 제대로 되지 않았을 때 발생하는 예외
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException e
+    ) {
+        log.warn("[HttpMessageNotReadableException] {}", e.getMessage(), e);
+
+        ExceptionResponse response = ExceptionResponse.of(BAD_REQUEST, "요청 본문을 읽을 수 없습니다");
+
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+    /***
+     * 요청 파라미터에서 사용되는 enum을 converter가 변환하지 못한 경우 발생하는 예외
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ExceptionResponse> handle(MethodArgumentTypeMismatchException e) {
+        log.warn("[MethodArgumentTypeMismatchException] {}", e.getMessage(), e);
+
+        ExceptionResponse response = ExceptionResponse.of(BAD_REQUEST, "요청 데이터 타입이 잘못되었습니다");
+
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+    /***
+     * 예기치 못한 서버 예외
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ExceptionResponse> handleException(final Exception e) {
+        log.warn("[Exception] {}", e.getMessage(), e);
+
+        ExceptionResponse response = ExceptionResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, "예기치 못한 서버 오류가 발생하였습니다");
+
+        return ResponseEntity.status(response.status()).body(response);
+    }
+
+}


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- 서비스 로직에 사용될 CustomException, ExceptionCode 추가
- 전역 예외 핸들러 (GlobalExceptionHandler) 추가

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항


## 🔗 이슈번호
#39 

---

<details open> <summary>스크린샷 & 비디오 </summary>


### HttpRequestMethodNotSupportedException : 해당 api(url)에 지원하지 않는 http 메서드 요청시 발생하는 예외
<img width="764" alt="스크린샷 2024-07-29 오후 11 34 30" src="https://github.com/user-attachments/assets/0862b886-f6ad-490d-8959-98eb7f624c2e">

### CustomException : 서비스 로직 전반에 사용되는 Custom 예외
<img width="762" alt="스크린샷 2024-07-29 오후 11 51 48" src="https://github.com/user-attachments/assets/9a0723c6-fa73-4f0e-ad8a-dcb7abe7f616">

### MethodArgumentTypeMismatchException : 요청 파라미터에서 사용되는 enum을 converter가 변환하지 못한 경우 발생하는 예외
<img width="757" alt="스크린샷 2024-07-29 오후 11 43 58" src="https://github.com/user-attachments/assets/a79e6a5a-a063-4092-8953-3c1950a4760a">

### HttpMessageNotReadableException : HTTP Body 파싱이 제대로 되지 않았을 때 발생하는 예외
<img width="761" alt="스크린샷 2024-07-29 오후 11 39 08" src="https://github.com/user-attachments/assets/b791159e-8415-4971-8d18-4e04c56a0fde">

### Exception : 예기치 못한 서버에러 발생
<img width="764" alt="image" src="https://github.com/user-attachments/assets/ccbb1e46-2c35-4875-aa2f-ff854df4cc54">

</details>
