### PR TITLE
[feat] API 요청 데이터 검증 validation 라이브러리 추가 및 GlobalExceptionHandler 예외 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
 	// web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// database
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/refooding/api/common/exception/FieldErrorResponse.java
+++ b/src/main/java/refooding/api/common/exception/FieldErrorResponse.java
@@ -1,0 +1,22 @@
+package refooding.api.common.exception;
+
+import org.springframework.validation.BindingResult;
+
+import java.util.List;
+
+public record FieldErrorResponse(
+        String filed,
+        Object rejectedValue,
+        String message
+) {
+    public static List<FieldErrorResponse> of(BindingResult bindingResult) {
+        return bindingResult
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> new FieldErrorResponse(
+                        fieldError.getField(),
+                        fieldError.getRejectedValue(),
+                        fieldError.getDefaultMessage()))
+                .toList();
+    }
+}

--- a/src/main/java/refooding/api/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/refooding/api/common/handler/GlobalExceptionHandler.java
@@ -5,11 +5,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import refooding.api.common.exception.CustomException;
 import refooding.api.common.exception.ExceptionResponse;
+import refooding.api.common.exception.FieldErrorResponse;
+
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
@@ -25,6 +29,18 @@ public class GlobalExceptionHandler{
         ExceptionResponse response = ExceptionResponse.of(e.getExceptionCode());
 
         return ResponseEntity.status(response.status()).body(response);
+    }
+
+    /**
+     * 요청 본문 유효성 검사
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<List<FieldErrorResponse>> handle(MethodArgumentNotValidException e) {
+        log.warn("[MethodArgumentNotValidException] {}", e.getMessage(), e);
+
+        List<FieldErrorResponse> response = FieldErrorResponse.of(e.getBindingResult());
+
+        return ResponseEntity.status(BAD_REQUEST).body(response);
     }
 
     /**


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- API 요청 데이터 검증 validation 라이브러리 추가 및 GlobalExceptionHandler 예외 추가

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항


## 🔗 이슈번호
#41 

---

<details open> <summary>스크린샷 & 비디오 </summary>

### MethodArgumentNotValidException : API 요청 본문 유효성 검사에 대한 에러 처리
<img width="764" alt="스크린샷 2024-07-30 오전 1 00 13" src="https://github.com/user-attachments/assets/88f15330-5579-425d-ab8c-bf1fe653f3c7">

</details>
