### PR TITLE
[feature] 레시피 찜 기능 구현

### DIFF
--- a/src/main/java/refooding/api/common/exception/ExceptionCode.java
+++ b/src/main/java/refooding/api/common/exception/ExceptionCode.java
@@ -10,6 +10,7 @@ public enum ExceptionCode {
     NOT_FOUND_EXCHANGE(HttpStatus.NOT_FOUND, "존재하지 않는 식재료 교환글 입니다"),
     NOT_FOUND_REGION(HttpStatus.NOT_FOUND, "존재하지 않는 지역입니다"),
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다"),
+    NOT_FOUND_RECIPE(HttpStatus.NOT_FOUND, "존재하지 않는 레시피입니다."),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다"),

--- a/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
@@ -97,4 +97,17 @@ public class RecipeController {
         }
     }
 
+    @GetMapping("/members/{memberId}/favorites")
+    @Operation(
+            summary = "멤버별 찜한 레시피 목록 조회",
+            responses = {
+            @ApiResponse(responseCode = "200", description = "찜 목록 조회 성공")
+    })
+    public ResponseEntity<Slice<RecipeResponse>> getFavoriteRecipesByMemberId(@PathVariable Long memberId,
+                                                                              @RequestParam(defaultValue = "0") int page,
+                                                                              @RequestParam(defaultValue = "5") int size) {
+        Slice<RecipeResponse> favoriteRecipes = recipeService.getFavoriteRecipesByMemberId(memberId, PageRequest.of(page, size));
+        return ResponseEntity.ok(favoriteRecipes);
+    }
+
 }

--- a/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
@@ -11,6 +11,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import refooding.api.common.exception.CustomException;
+import refooding.api.common.exception.ExceptionCode;
+import refooding.api.domain.recipe.dto.FavoriteRecipeToggleResponse;
 import refooding.api.domain.recipe.dto.RecipeDetailResponse;
 import refooding.api.domain.recipe.dto.RecipeResponse;
 import refooding.api.domain.recipe.service.RecipeService;
@@ -72,6 +75,26 @@ public class RecipeController {
     public ResponseEntity<RecipeDetailResponse> getRecipeDetailById(@PathVariable Long recipeId) {
         RecipeDetailResponse response = recipeService.getRecipeDetailById(recipeId);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/toggle-favorite/{memberId}/{recipeId}")
+    @Operation(
+            summary = "레시피 찜/찜 해제 토글",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "레시피 찜 상태 토글 성공"),
+                    @ApiResponse(responseCode = "404", description = "레시피 또는 멤버를 찾을 수 없음")
+            }
+    )
+    public ResponseEntity<?> toggleFavoriteRecipe(@PathVariable Long memberId, @PathVariable Long recipeId) {
+        try {
+            boolean isFavorited = recipeService.toggleFavoriteRecipe(memberId, recipeId);
+            String message = isFavorited ? "찜 상태로 바뀌었습니다." : "찜 상태가 해제되었습니다.";
+            return ResponseEntity.ok().body(FavoriteRecipeToggleResponse.builder().success(true).message(message).build());
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getExceptionCode().getStatus()).body(FavoriteRecipeToggleResponse.builder().success(false).message(e.getMessage()).build());
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body(FavoriteRecipeToggleResponse.builder().success(false).message(ExceptionCode.INTERNAL_SERVER_ERROR.getMessage()).build());
+        }
     }
 
 }

--- a/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
@@ -86,15 +86,9 @@ public class RecipeController {
             }
     )
     public ResponseEntity<?> toggleFavoriteRecipe(@PathVariable Long memberId, @PathVariable Long recipeId) {
-        try {
             boolean isFavorited = recipeService.toggleFavoriteRecipe(memberId, recipeId);
             String message = isFavorited ? "찜 상태로 바뀌었습니다." : "찜 상태가 해제되었습니다.";
             return ResponseEntity.ok().body(FavoriteRecipeToggleResponse.builder().success(true).message(message).build());
-        } catch (CustomException e) {
-            return ResponseEntity.status(e.getExceptionCode().getStatus()).body(FavoriteRecipeToggleResponse.builder().success(false).message(e.getMessage()).build());
-        } catch (Exception e) {
-            return ResponseEntity.internalServerError().body(FavoriteRecipeToggleResponse.builder().success(false).message(ExceptionCode.INTERNAL_SERVER_ERROR.getMessage()).build());
-        }
     }
 
     @GetMapping("/members/{memberId}/favorites")

--- a/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
+++ b/src/main/java/refooding/api/domain/recipe/controller/RecipeController.java
@@ -85,7 +85,7 @@ public class RecipeController {
                     @ApiResponse(responseCode = "404", description = "레시피 또는 멤버를 찾을 수 없음")
             }
     )
-    public ResponseEntity<?> toggleFavoriteRecipe(@PathVariable Long memberId, @PathVariable Long recipeId) {
+    public ResponseEntity<FavoriteRecipeToggleResponse> toggleFavoriteRecipe(@PathVariable Long memberId, @PathVariable Long recipeId) {
             boolean isFavorited = recipeService.toggleFavoriteRecipe(memberId, recipeId);
             String message = isFavorited ? "찜 상태로 바뀌었습니다." : "찜 상태가 해제되었습니다.";
             return ResponseEntity.ok().body(FavoriteRecipeToggleResponse.builder().success(true).message(message).build());

--- a/src/main/java/refooding/api/domain/recipe/dto/FavoriteRecipeToggleResponse.java
+++ b/src/main/java/refooding/api/domain/recipe/dto/FavoriteRecipeToggleResponse.java
@@ -1,0 +1,13 @@
+package refooding.api.domain.recipe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class FavoriteRecipeToggleResponse {
+    private boolean success;
+    private String message;
+}

--- a/src/main/java/refooding/api/domain/recipe/entity/FavoriteRecipe.java
+++ b/src/main/java/refooding/api/domain/recipe/entity/FavoriteRecipe.java
@@ -1,0 +1,44 @@
+package refooding.api.domain.recipe.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import refooding.api.common.domain.BaseTimeEntity;
+import refooding.api.domain.member.entity.Member;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FavoriteRecipe extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    @Builder
+    public FavoriteRecipe(Member member, Recipe recipe) {
+        this.member = member;
+        this.recipe = recipe;
+    }
+
+    // == 연관관계 편의 메소드 == //
+
+    public void changeMember(Member member) {
+        this.member = member;
+    }
+
+    public void changeRecipe(Recipe recipe) {
+        this.recipe = recipe;
+    }
+
+}

--- a/src/main/java/refooding/api/domain/recipe/entity/FavoriteRecipe.java
+++ b/src/main/java/refooding/api/domain/recipe/entity/FavoriteRecipe.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import refooding.api.common.domain.BaseTimeEntity;
 import refooding.api.domain.member.entity.Member;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +31,14 @@ public class FavoriteRecipe extends BaseTimeEntity {
     public FavoriteRecipe(Member member, Recipe recipe) {
         this.member = member;
         this.recipe = recipe;
+    }
+
+    public void delete(){
+        this.deletedDate = LocalDateTime.now();
+    }
+
+    public void unDelete() {
+        this.deletedDate = null;
     }
 
     // == 연관관계 편의 메소드 == //

--- a/src/main/java/refooding/api/domain/recipe/entity/Recipe.java
+++ b/src/main/java/refooding/api/domain/recipe/entity/Recipe.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import refooding.api.common.domain.BaseTimeEntity;
+import refooding.api.domain.member.entity.Member;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -36,6 +37,10 @@ public class Recipe extends BaseTimeEntity {
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true) // Recipe 엔티티 삭제시 해당 엔티티의 PK를 FK로 가지고 있는 recipeIngredient도 삭제
     private Set<RecipeIngredient> recipeIngredientList = new HashSet<>();
 
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true) // Recipe 엔티티 삭제시 해당 엔티티의 PK를 FK로 가지고 있는 favoriteRecipe도 삭제
+    private Set<FavoriteRecipe> favoriteRecipeList = new HashSet<>();
+
+
     @Builder
     public Recipe(String name, String tip, String mainIngredientName, String mainImgSrc) {
         this.name = name;
@@ -62,5 +67,16 @@ public class Recipe extends BaseTimeEntity {
     public void addRecipeIngredient(RecipeIngredient recipeIngredient) {
         recipeIngredientList.add(recipeIngredient);
         recipeIngredient.changeRecipe(this);
+    }
+
+    /**
+     * Recipe, FavoriteRecipe 연관관계 설정 메솓,
+     * @param favoriteRecipe
+     * @param member
+     */
+    public void addFavoriteRecipe(FavoriteRecipe favoriteRecipe, Member member) {
+        favoriteRecipeList.add(favoriteRecipe);
+        favoriteRecipe.changeMember(member);
+        favoriteRecipe.changeRecipe(this);
     }
 }

--- a/src/main/java/refooding/api/domain/recipe/entity/Recipe.java
+++ b/src/main/java/refooding/api/domain/recipe/entity/Recipe.java
@@ -69,14 +69,4 @@ public class Recipe extends BaseTimeEntity {
         recipeIngredient.changeRecipe(this);
     }
 
-    /**
-     * Recipe, FavoriteRecipe 연관관계 설정 메솓,
-     * @param favoriteRecipe
-     * @param member
-     */
-    public void addFavoriteRecipe(FavoriteRecipe favoriteRecipe, Member member) {
-        favoriteRecipeList.add(favoriteRecipe);
-        favoriteRecipe.changeMember(member);
-        favoriteRecipe.changeRecipe(this);
-    }
 }

--- a/src/main/java/refooding/api/domain/recipe/repository/FavoriteRecipeRepository.java
+++ b/src/main/java/refooding/api/domain/recipe/repository/FavoriteRecipeRepository.java
@@ -1,10 +1,18 @@
 package refooding.api.domain.recipe.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import refooding.api.domain.recipe.entity.FavoriteRecipe;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FavoriteRecipeRepository extends JpaRepository<FavoriteRecipe, Long> {
     Optional<FavoriteRecipe> findByMemberIdAndRecipeId(Long memberId, Long recipeId);
+
+    @Query("SELECT fr.recipe.id FROM FavoriteRecipe fr WHERE fr.member.id = :memberId AND fr.deletedDate IS NULL")
+    List<Long> findRecipeIdsByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/refooding/api/domain/recipe/repository/FavoriteRecipeRepository.java
+++ b/src/main/java/refooding/api/domain/recipe/repository/FavoriteRecipeRepository.java
@@ -1,2 +1,10 @@
-package refooding.api.domain.recipe.repository;public interface FavoriteRecipeRepository {
+package refooding.api.domain.recipe.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import refooding.api.domain.recipe.entity.FavoriteRecipe;
+
+import java.util.Optional;
+
+public interface FavoriteRecipeRepository extends JpaRepository<FavoriteRecipe, Long> {
+    Optional<FavoriteRecipe> findByMemberIdAndRecipeId(Long memberId, Long recipeId);
 }

--- a/src/main/java/refooding/api/domain/recipe/repository/FavoriteRecipeRepository.java
+++ b/src/main/java/refooding/api/domain/recipe/repository/FavoriteRecipeRepository.java
@@ -1,0 +1,2 @@
+package refooding.api.domain.recipe.repository;public interface FavoriteRecipeRepository {
+}

--- a/src/main/java/refooding/api/domain/recipe/repository/RecipeRepository.java
+++ b/src/main/java/refooding/api/domain/recipe/repository/RecipeRepository.java
@@ -24,4 +24,7 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     @Query("select r from Recipe r where r.mainIngredientName in :ingredientNames")
     Slice<Recipe> findByMainIngredientNames(List<String> ingredientNames, Pageable pageable);
+
+    @Query("SELECT r FROM Recipe r WHERE r.id IN :recipeIds")
+    Slice<Recipe> findAllRecipesByIds(List<Long> recipeIds, Pageable pageable);  // 메소드 이름 변경 및 Slice 반환
 }

--- a/src/main/java/refooding/api/domain/recipe/service/RecipeService.java
+++ b/src/main/java/refooding/api/domain/recipe/service/RecipeService.java
@@ -228,7 +228,12 @@ public class RecipeService {
 
     // == 레시피 찜 기능 == //
 
-    // 레시피 찜/찜 해제
+    /**
+     * 레시피 찜/찜 해제 토글
+     * @param memberId
+     * @param recipeId
+     * @return
+     */
     @Transactional
     public boolean toggleFavoriteRecipe(Long memberId, Long recipeId) {
 
@@ -267,5 +272,27 @@ public class RecipeService {
         }
     }
 
+    /**
+     * member별 레시피 찜 리스트 조회
+     * @param memberId
+     * @param pageable
+     * @return
+     */
+    public Slice<RecipeResponse> getFavoriteRecipesByMemberId(Long memberId, Pageable pageable) {
+        List<Long> recipeIds = favoriteRecipeRepository.findRecipeIdsByMemberId(memberId);
+
+        Slice<Recipe> findRecipes = recipeRepository.findAllRecipesByIds(recipeIds, pageable);
+        // DTO 변환
+        List<RecipeResponse> recipeResponses = findRecipes.getContent().stream()
+                .map(recipe -> RecipeResponse.builder()
+                        .id(recipe.getId())
+                        .name(recipe.getName())
+                        .imgSrc(recipe.getMainImgSrc())
+                        .build())
+                .toList();
+
+        // Slice로 변환 후 반환
+        return new SliceImpl<>(recipeResponses, pageable, findRecipes.hasNext());
+    }
 
 }

--- a/src/main/java/refooding/api/domain/recipe/service/RecipeService.java
+++ b/src/main/java/refooding/api/domain/recipe/service/RecipeService.java
@@ -8,11 +8,16 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import refooding.api.common.exception.CustomException;
+import refooding.api.common.exception.ExceptionCode;
+import refooding.api.domain.member.entity.Member;
+import refooding.api.domain.member.repository.MemberRepository;
 import refooding.api.domain.recipe.dto.ManualResponse;
 import refooding.api.domain.recipe.dto.RecipeDetailResponse;
 import refooding.api.domain.recipe.dto.RecipeIngredientResponse;
 import refooding.api.domain.recipe.dto.RecipeResponse;
 import refooding.api.domain.recipe.entity.*;
+import refooding.api.domain.recipe.repository.FavoriteRecipeRepository;
 import refooding.api.domain.recipe.repository.IngredientRepository;
 import refooding.api.domain.recipe.repository.RecipeRepository;
 
@@ -30,6 +35,10 @@ public class RecipeService {
     private final RecipeRepository recipeRepository;
 
     private final IngredientRepository ingredientRepository;
+
+    private final FavoriteRecipeRepository favoriteRecipeRepository;
+
+    private final MemberRepository memberRepository;
 
     @PostConstruct
     public void init() {
@@ -216,6 +225,44 @@ public class RecipeService {
                 .build();
     }
 
+
+    // == 레시피 찜 기능 == //
+
+    // 레시피 찜/찜 해제
+    @Transactional
+    public void toggleFavoriteRecipe(Long memberId, Long recipeId) {
+
+        Optional<FavoriteRecipe> favoriteOptional = favoriteRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId);
+
+        if (favoriteOptional.isPresent()) {
+            // 찜이 이미 존재한다면, 상태를 토글
+            FavoriteRecipe favoriteRecipe = favoriteOptional.get();
+            // 현재 찜 상태라면, 찜 해제
+            if (favoriteRecipe.getDeletedDate() == null) {
+                favoriteRecipe.delete();
+            } else {
+                // 현재 찜 해제 상태라면, 찜 상태로 전환
+                favoriteRecipe.unDelete();
+            }
+        } else {
+            // 찜 목록에 없는 경우(favorite_recipe 테이블에 없는 경우), 새로 favoriteRecipe 엔티티 생성 후, 바로 찜 상태로 설정
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_MEMBER));
+            Recipe recipe = recipeRepository.findById(recipeId)
+                    .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_RECIPE));
+            // FavoriteRecipe 생성
+            FavoriteRecipe newFavorite = FavoriteRecipe.builder()
+                    .member(member)
+                    .recipe(recipe)
+                    .build();
+
+            // 연관관계 설정
+            newFavorite.changeMember(member);
+            newFavorite.changeRecipe(recipe);
+
+            favoriteRecipeRepository.save(newFavorite);
+        }
+    }
 
 
 }

--- a/src/main/java/refooding/api/domain/recipe/service/RecipeService.java
+++ b/src/main/java/refooding/api/domain/recipe/service/RecipeService.java
@@ -230,7 +230,7 @@ public class RecipeService {
 
     // 레시피 찜/찜 해제
     @Transactional
-    public void toggleFavoriteRecipe(Long memberId, Long recipeId) {
+    public boolean toggleFavoriteRecipe(Long memberId, Long recipeId) {
 
         Optional<FavoriteRecipe> favoriteOptional = favoriteRecipeRepository.findByMemberIdAndRecipeId(memberId, recipeId);
 
@@ -240,9 +240,11 @@ public class RecipeService {
             // 현재 찜 상태라면, 찜 해제
             if (favoriteRecipe.getDeletedDate() == null) {
                 favoriteRecipe.delete();
+                return false;
             } else {
                 // 현재 찜 해제 상태라면, 찜 상태로 전환
                 favoriteRecipe.unDelete();
+                return true;
             }
         } else {
             // 찜 목록에 없는 경우(favorite_recipe 테이블에 없는 경우), 새로 favoriteRecipe 엔티티 생성 후, 바로 찜 상태로 설정
@@ -261,6 +263,7 @@ public class RecipeService {
             newFavorite.changeRecipe(recipe);
 
             favoriteRecipeRepository.save(newFavorite);
+            return true;
         }
     }
 


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약

레시피 찜 기능 구현

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)

테스트용 Member는 추후 Oauth 구현 후 변경


## 🔀 변경사항

테스트용 Member별 찜/찜 해제 토글 API 구현
테스트용 Member별 찜한 레시피 리스트 조회 API 구현

Member와 레시피를 중간에 찜레시피라는 매핑 테이블을 둬서  N:N 연결하는 것이 아니라,
레시피와 찜 레시피를 1:N으로 연결한 후, 찜 레시피 테이블에서 memberId를 통해 찜 레시피id를 찾는 방식으로 변경해 Member 엔티티의 복잡도를 낮추는 방식으로 구현


## 🔗 이슈번호
#44 

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
