### PR TITLE
[refactor] 식재료 교환 지역명 변경, 식재료 교환 상세조회 응답 회원 정보 추가

### DIFF
--- a/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeDetailResponse.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeDetailResponse.java
@@ -9,11 +9,12 @@ public record ExchangeDetailResponse(
         Long id,
         String title,
         String content,
+        Long memberId,
+        String username,
         String region,
         String childRegion,
         ExchangeStatus status,
         LocalDateTime createDate
-        // 회원 추가
         // 이미지 추가
 ) {
     public static ExchangeDetailResponse from(Exchange exchange) {
@@ -21,6 +22,8 @@ public record ExchangeDetailResponse(
                 exchange.getId(),
                 exchange.getTitle(),
                 exchange.getContent(),
+                exchange.getMember().getId(),
+                exchange.getMember().getName(),
                 exchange.getRegion().getParent().getName(),
                 exchange.getRegion().getName(),
                 exchange.getStatus(),

--- a/src/main/resources/exchange-data.sql
+++ b/src/main/resources/exchange-data.sql
@@ -1,6 +1,6 @@
-INSERT INTO Region (name) VALUES ('서울');
-INSERT INTO Region (name) VALUES ('경기');
-INSERT INTO Region (name) VALUES ('인천');
+INSERT INTO Region (name) VALUES ('서울특별시');
+INSERT INTO Region (name) VALUES ('경기도');
+INSERT INTO Region (name) VALUES ('인천광역시');
 INSERT INTO Region (name) VALUES ('대전광역시');
 INSERT INTO Region (name) VALUES ('대구광역시');
 INSERT INTO Region (name) VALUES ('부산광역시');


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- 식재료 교환 지역명 변경
- 식재료 교환 상세조회 응답 회원 정보 추가

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항
- 식재료 교환 지역명 변경
 - **서울 -> 서울특별시 / 경기 -> 경기도**
- 식재료 교환 상세조회 응답 회원 정보 추가
```java
public record ExchangeDetailResponse(
        Long id,
        String title,
        String content,
        **Long memberId,
        String username,**
        String region,
        String childRegion,
        ExchangeStatus status,
        LocalDateTime createDate
        // 이미지 추가
) {...}
```

## 🔗 이슈번호
#48 

---

<details open> <summary>스크린샷 & 비디오 </summary>

- 식재료 교환 지역명 변경
<img width="761" alt="스크린샷 2024-08-01 오후 5 20 25" src="https://github.com/user-attachments/assets/38ed10ee-096a-4151-8225-b1535ec97dc0">

- 식재료 교환 상세조회 응답 회원 정보 추가
<img width="770" alt="스크린샷 2024-08-01 오후 5 20 16" src="https://github.com/user-attachments/assets/16d5f2d3-27a2-4eac-b89e-51107ce4a66c">

</details>
