### PR TITLE
[fix] 식재료 목록 조회시 삭제된 데이터 반영하여 조회

### DIFF
--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepositoryImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepositoryImpl.java
@@ -50,7 +50,8 @@ public class ExchangeCustomRepositoryImpl implements ExchangeCustomRepository{
                         keywordContains(condition.keyword()),
                         statusEq(condition.status()),
                         regionEq(condition.regionId()),
-                        cursorCondition(condition.lastExchangeId())
+                        cursorCondition(condition.lastExchangeId()),
+                        notDeleted()
                 )
                 .orderBy(exchange.id.desc());
 
@@ -71,6 +72,10 @@ public class ExchangeCustomRepositoryImpl implements ExchangeCustomRepository{
 
     private BooleanExpression cursorCondition(Long lastExchangeId){
         return lastExchangeId == null ? null : exchange.id.lt(lastExchangeId);
+    }
+
+    private static BooleanExpression notDeleted() {
+        return exchange.deletedDate.isNull();
     }
 
 

--- a/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
@@ -91,7 +91,7 @@ public class ExchangeServiceImpl implements ExchangeService{
         Member findMember = getMemberById(memberId);
 
         Exchange exchange = getById(exchangeId);
-        if (exchange.validateMember(findMember.getId())) {
+        if (!exchange.validateMember(findMember.getId())) {
             throw new CustomException(ExceptionCode.UNAUTHORIZED);
         }
 


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- 식재료 목록 조회시 삭제된 데이터 모두 조회되는 버그 수정

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항
- 식재료 교환글 삭제 회원 검증 로직 수정

## 🔗 이슈번호
#54 

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
