### PR TITLE
[feat] 채팅방 나가기, 채팅 목록 응답에 마지막 메시지 읽음 여부 데이터 추가

### DIFF
--- a/src/main/java/refooding/api/domain/chat/controller/RoomController.java
+++ b/src/main/java/refooding/api/domain/chat/controller/RoomController.java
@@ -35,5 +35,12 @@ public class RoomController implements RoomControllerOpenApi{
         return ResponseEntity.ok(response);
     }
 
+    @Override
+    @DeleteMapping("/{roomId}")
+    public ResponseEntity<Void> exitRoom(@PathVariable Long roomId) {
+        roomService.exitRoom(roomId);
+        return ResponseEntity.noContent().build();
+    }
+
 
 }

--- a/src/main/java/refooding/api/domain/chat/controller/RoomController.java
+++ b/src/main/java/refooding/api/domain/chat/controller/RoomController.java
@@ -3,7 +3,6 @@ package refooding.api.domain.chat.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import refooding.api.domain.chat.dto.request.RoomCreateRequest;
 import refooding.api.domain.chat.dto.response.RoomResponse;
@@ -19,6 +18,9 @@ public class RoomController implements RoomControllerOpenApi{
 
     private final RoomService roomService;
 
+    /**
+     * 채팅방 생성
+     */
     @Override
     @PostMapping
     public ResponseEntity<Void> getOrCreate(@Valid @RequestBody RoomCreateRequest request) {
@@ -27,14 +29,20 @@ public class RoomController implements RoomControllerOpenApi{
         return ResponseEntity.created(URI.create("/chat/rooms/" + roomId)).build();
     }
 
+    /**
+     * 채팅방 목록 조회
+     */
     @Override
     @GetMapping
     public ResponseEntity<List<RoomResponse>> getJoinRooms() {
         // TODO : 인증 추가
-        List<RoomResponse> response = roomService.getRoomListByMemberId();
+        List<RoomResponse> response = roomService.getJoinRoomsByMemberId();
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 채팅방 나가기
+     */
     @Override
     @DeleteMapping("/{roomId}")
     public ResponseEntity<Void> exitRoom(@PathVariable Long roomId) {

--- a/src/main/java/refooding/api/domain/chat/controller/RoomControllerOpenApi.java
+++ b/src/main/java/refooding/api/domain/chat/controller/RoomControllerOpenApi.java
@@ -36,4 +36,17 @@ public interface RoomControllerOpenApi {
     )
     ResponseEntity<List<RoomResponse>> getJoinRooms();
 
+    @Operation(
+            summary = "채팅방 나가기",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "채팅방 나가기 성공"
+                    )
+            }
+    )
+    ResponseEntity<Void> exitRoom(Long roomId);
+
+
+
 }

--- a/src/main/java/refooding/api/domain/chat/dto/response/RoomResponse.java
+++ b/src/main/java/refooding/api/domain/chat/dto/response/RoomResponse.java
@@ -1,6 +1,5 @@
 package refooding.api.domain.chat.dto.response;
 
-import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record RoomResponse(
@@ -14,10 +13,11 @@ public record RoomResponse(
         String senderName,
 
         @Schema(description = "마지막 메시지 내용")
-        String lastMessage
+        String lastMessage,
+
+        @Schema(description = "읽지 않은 메시지 여부")
+        boolean isUnread
+
         // TODO : 프로필 이미지
 ) {
-    @QueryProjection
-    public RoomResponse {
-    }
 }

--- a/src/main/java/refooding/api/domain/chat/entity/Message.java
+++ b/src/main/java/refooding/api/domain/chat/entity/Message.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import refooding.api.common.domain.BaseTimeEntity;
 import refooding.api.domain.member.entity.Member;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -35,6 +37,28 @@ public class Message extends BaseTimeEntity {
         this.status = MessageStatus.UNREAD;
         this.sender = sender;
         this.room = room;
+    }
+
+    public boolean isUnreadByMember(RoomMember roomMember) {
+        if (isSentByMember(roomMember)) {
+            return false;
+        }
+
+        return isMessageNewerThanLastRead(roomMember);
+    }
+
+    private boolean isSentByMember(RoomMember roomMember) {
+        Member member = roomMember.getMember();
+
+        // 마지막 메시지가 자신이 보낸 메시지라면 알림 필요 X
+        return sender.getId().equals(member.getId());
+    }
+
+    private boolean isMessageNewerThanLastRead(RoomMember roomMember) {
+        LocalDateTime lastReadTime = roomMember.getLastReadTime();
+
+        // 마지막으로 읽은 시간이 없거나, 마지막으로 읽은 시간보다 마지막 메시지의 생성 날짜가 더 클 때
+        return lastReadTime == null || this.getCreatedDate().isAfter(lastReadTime);
     }
 
 }

--- a/src/main/java/refooding/api/domain/chat/entity/Message.java
+++ b/src/main/java/refooding/api/domain/chat/entity/Message.java
@@ -20,10 +20,6 @@ public class Message extends BaseTimeEntity {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private MessageStatus status;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member sender;
@@ -34,7 +30,6 @@ public class Message extends BaseTimeEntity {
 
     public Message(String content, Member sender, Room room) {
         this.content = content;
-        this.status = MessageStatus.UNREAD;
         this.sender = sender;
         this.room = room;
     }

--- a/src/main/java/refooding/api/domain/chat/entity/MessageStatus.java
+++ b/src/main/java/refooding/api/domain/chat/entity/MessageStatus.java
@@ -1,5 +1,0 @@
-package refooding.api.domain.chat.entity;
-
-public enum MessageStatus {
-    READ, UNREAD
-}

--- a/src/main/java/refooding/api/domain/chat/entity/Room.java
+++ b/src/main/java/refooding/api/domain/chat/entity/Room.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import refooding.api.common.domain.BaseTimeEntity;
 import refooding.api.domain.exchange.entity.Exchange;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,6 +34,10 @@ public class Room extends BaseTimeEntity {
 
     public void updateMessage(Message message) {
         messages.add(message);
+    }
+
+    public void delete(){
+        this.deletedDate = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/refooding/api/domain/chat/entity/RoomMember.java
+++ b/src/main/java/refooding/api/domain/chat/entity/RoomMember.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import refooding.api.common.domain.BaseTimeEntity;
 import refooding.api.domain.member.entity.Member;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -43,6 +45,10 @@ public class RoomMember extends BaseTimeEntity {
 
     public void exit() {
         this.status = RoomMemberStatus.EXIT;
+    }
+
+    public void delete() {
+        this.deletedDate = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/refooding/api/domain/chat/entity/RoomMember.java
+++ b/src/main/java/refooding/api/domain/chat/entity/RoomMember.java
@@ -37,10 +37,12 @@ public class RoomMember extends BaseTimeEntity {
         this.member = member;
         this.room = room;
         this.status = RoomMemberStatus.JOIN;
+        this.joinedTime = LocalDateTime.now();
     }
 
     public void join() {
         this.status = RoomMemberStatus.JOIN;
+        this.joinedTime = LocalDateTime.now();
     }
 
     public boolean isJoin() {

--- a/src/main/java/refooding/api/domain/chat/entity/RoomMember.java
+++ b/src/main/java/refooding/api/domain/chat/entity/RoomMember.java
@@ -29,6 +29,10 @@ public class RoomMember extends BaseTimeEntity {
     @Column(nullable = false)
     private RoomMemberStatus status;
 
+    private LocalDateTime joinedTime;
+
+    private LocalDateTime lastReadTime;
+
     public RoomMember(Member member, Room room) {
         this.member = member;
         this.room = room;
@@ -49,6 +53,10 @@ public class RoomMember extends BaseTimeEntity {
 
     public void delete() {
         this.deletedDate = LocalDateTime.now();
+    }
+
+    public void updateLastReadTime() {
+        this.lastReadTime = LocalDateTime.now();
     }
 
 }

--- a/src/main/java/refooding/api/domain/chat/repository/MessageCustomRepository.java
+++ b/src/main/java/refooding/api/domain/chat/repository/MessageCustomRepository.java
@@ -5,5 +5,5 @@ import refooding.api.domain.chat.entity.Message;
 import java.util.List;
 
 public interface MessageCustomRepository {
-    List<Message> findLatestMessageWithSenderByRoomId(List<Long> roomIds);
+    List<Message> findLatestMessagesByRoomIds(List<Long> roomIds);
 }

--- a/src/main/java/refooding/api/domain/chat/repository/MessageCustomRepositoryImpl.java
+++ b/src/main/java/refooding/api/domain/chat/repository/MessageCustomRepositoryImpl.java
@@ -19,7 +19,7 @@ public class MessageCustomRepositoryImpl implements MessageCustomRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<Message> findLatestMessageWithSenderByRoomId(List<Long> roomIds) {
+    public List<Message> findLatestMessagesByRoomIds(List<Long> roomIds) {
 
         QMessage subMessage = new QMessage("subMessage");
 

--- a/src/main/java/refooding/api/domain/chat/repository/RoomMemberRepository.java
+++ b/src/main/java/refooding/api/domain/chat/repository/RoomMemberRepository.java
@@ -1,10 +1,9 @@
 package refooding.api.domain.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import refooding.api.domain.chat.entity.RoomMember;
-import refooding.api.domain.chat.entity.Room;
-import refooding.api.domain.member.entity.Member;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,15 +14,24 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
             "from RoomMember roomMember " +
             "where roomMember.member.id = :memberId " +
             "and roomMember.status = 'JOIN'")
-    List<RoomMember> findAllJoinedRoomsByMemberId(Long memberId);
+    List<RoomMember> findRoomMembersJoinedRoomsByMemberId(Long memberId);
 
     @Query("select roomMember " +
             "from RoomMember roomMember " +
             "left join fetch roomMember.member member " +
             "left join roomMember.room room " +
             "where roomMember.member.id in (:memberIds) " +
-            "and room.exchange.id = :exchangeId")
-    List<RoomMember> findAllByMemberIdsInAndExchangeId(List<Long> memberIds, Long exchangeId);
+            "and room.exchange.id = :exchangeId " +
+            "and roomMember.deletedDate is null")
+    List<RoomMember> findRoomMembersByMemberIdsInAndExchangeId(List<Long> memberIds, Long exchangeId);
 
-    Optional<RoomMember> findJoinRoomByMemberAndRoom(Member member, Room room);
+    List<RoomMember> findRoomMembersByRoomId(Long roomId);
+
+    Optional<RoomMember> findJoinRoomByMemberIdAndRoomId(Long memberId, Long roomId);
+
+    @Modifying
+    @Query("update RoomMember roomMember " +
+            "set roomMember.deletedDate = now()" +
+            "where roomMember.id in(:roomMemberIds)")
+    void deleteAllRoomMember(List<Long> roomMemberIds);
 }

--- a/src/main/java/refooding/api/domain/chat/repository/RoomMemberRepository.java
+++ b/src/main/java/refooding/api/domain/chat/repository/RoomMemberRepository.java
@@ -19,6 +19,7 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
 
     @Query("select roomMember " +
             "from RoomMember roomMember " +
+            "left join fetch roomMember.member member " +
             "left join roomMember.room room " +
             "where roomMember.member.id in (:memberIds) " +
             "and room.exchange.id = :exchangeId")

--- a/src/main/java/refooding/api/domain/chat/repository/RoomMemberRepository.java
+++ b/src/main/java/refooding/api/domain/chat/repository/RoomMemberRepository.java
@@ -14,7 +14,7 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
             "from RoomMember roomMember " +
             "where roomMember.member.id = :memberId " +
             "and roomMember.status = 'JOIN'")
-    List<RoomMember> findRoomMembersJoinedRoomsByMemberId(Long memberId);
+    List<RoomMember> findJoinedRoomsByMemberId(Long memberId);
 
     @Query("select roomMember " +
             "from RoomMember roomMember " +
@@ -23,10 +23,21 @@ public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
             "where roomMember.member.id in (:memberIds) " +
             "and room.exchange.id = :exchangeId " +
             "and roomMember.deletedDate is null")
-    List<RoomMember> findRoomMembersByMemberIdsInAndExchangeId(List<Long> memberIds, Long exchangeId);
+    List<RoomMember> findRoomMembersByMemberIdsAndExchangeId(List<Long> memberIds, Long exchangeId);
 
+    @Query("select roomMember " +
+            "from RoomMember roomMember " +
+            "left join fetch roomMember.room room " +
+            "left join fetch roomMember.member member " +
+            "where room.id = :roomId " +
+            "and roomMember.deletedDate is null")
     List<RoomMember> findRoomMembersByRoomId(Long roomId);
 
+    @Query("select roomMember " +
+            "from RoomMember roomMember " +
+            "where roomMember.member.id = :memberId " +
+            "and roomMember.id = :roomId " +
+            "and roomMember.deletedDate is null")
     Optional<RoomMember> findJoinRoomByMemberIdAndRoomId(Long memberId, Long roomId);
 
     @Modifying

--- a/src/main/java/refooding/api/domain/chat/repository/RoomRepository.java
+++ b/src/main/java/refooding/api/domain/chat/repository/RoomRepository.java
@@ -1,9 +1,15 @@
 package refooding.api.domain.chat.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import refooding.api.domain.chat.entity.Room;
 
+import java.util.Optional;
+
 public interface RoomRepository extends JpaRepository<Room, Long>{
-
-
+    @Query("select room " +
+            "from Room room " +
+            "where room.id = :roomId " +
+            "and room.deletedDate is null")
+    Optional<Room> findRoomById(Long roomId);
 }

--- a/src/main/java/refooding/api/domain/chat/service/MessageServiceImpl.java
+++ b/src/main/java/refooding/api/domain/chat/service/MessageServiceImpl.java
@@ -26,24 +26,25 @@ public class MessageServiceImpl implements MessageService{
     private final MessageRepository messageRepository;
     private final RoomRepository roomRepository;
     private final MemberRepository memberRepository;
-    private final RoomMemberRepository joinRoomRepository;
+    private final RoomMemberRepository roomMemberRepository;
     private final SimpMessagingTemplate messagingTemplate;
 
     @Override
     @Transactional
     public void sendMessage(MessageRequest request) {
 
-        Member sender = memberRepository.findByIdAndDeletedDateIsNull(request.senderId())
+        Member findSender = memberRepository.findByIdAndDeletedDateIsNull(request.senderId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_MEMBER));
         Room findRoom = roomRepository.findRoomById(request.roomId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_CHAT_ROOM));
 
         // 메시지 발신 회원이 해당 채팅방에 참여중인 회원인지 확인
-        joinRoomRepository.findJoinRoomByMemberIdAndRoomId(sender.getId(), findRoom.getId())
+        roomMemberRepository.findJoinRoomByMemberIdAndRoomId(findSender.getId(), findRoom.getId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_CHAT_ROOM));
 
-        Message message = request.toMessage(sender, findRoom);
+        Message message = request.toMessage(findSender, findRoom);
         Message savedMessage = messageRepository.save(message);
+
         MessageResponse response = MessageResponse.from(savedMessage);
         messagingTemplate.convertAndSend(
                 String.format("/sub/chat/rooms/%s", findRoom.getId()),

--- a/src/main/java/refooding/api/domain/chat/service/MessageServiceImpl.java
+++ b/src/main/java/refooding/api/domain/chat/service/MessageServiceImpl.java
@@ -33,7 +33,7 @@ public class MessageServiceImpl implements MessageService{
     @Transactional
     public void sendMessage(MessageRequest request) {
 
-        Member sender = memberRepository.findById(request.senderId())
+        Member sender = memberRepository.findByIdAndDeletedDateIsNull(request.senderId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_MEMBER));
         Room findRoom = roomRepository.findById(request.roomId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_CHAT_ROOM));

--- a/src/main/java/refooding/api/domain/chat/service/MessageServiceImpl.java
+++ b/src/main/java/refooding/api/domain/chat/service/MessageServiceImpl.java
@@ -35,11 +35,11 @@ public class MessageServiceImpl implements MessageService{
 
         Member sender = memberRepository.findByIdAndDeletedDateIsNull(request.senderId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_MEMBER));
-        Room findRoom = roomRepository.findById(request.roomId())
+        Room findRoom = roomRepository.findRoomById(request.roomId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_CHAT_ROOM));
 
         // 메시지 발신 회원이 해당 채팅방에 참여중인 회원인지 확인
-        joinRoomRepository.findJoinRoomByMemberAndRoom(sender, findRoom)
+        joinRoomRepository.findJoinRoomByMemberIdAndRoomId(sender.getId(), findRoom.getId())
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_CHAT_ROOM));
 
         Message message = request.toMessage(sender, findRoom);

--- a/src/main/java/refooding/api/domain/chat/service/RoomService.java
+++ b/src/main/java/refooding/api/domain/chat/service/RoomService.java
@@ -9,4 +9,6 @@ public interface RoomService {
     Long getOrCreate(RoomCreateRequest request);
 
     List<RoomResponse> getRoomListByMemberId();
+
+    void exitRoom(Long roomId);
 }

--- a/src/main/java/refooding/api/domain/chat/service/RoomService.java
+++ b/src/main/java/refooding/api/domain/chat/service/RoomService.java
@@ -8,7 +8,7 @@ import java.util.List;
 public interface RoomService {
     Long getOrCreate(RoomCreateRequest request);
 
-    List<RoomResponse> getRoomListByMemberId();
+    List<RoomResponse> getJoinRoomsByMemberId();
 
     void exitRoom(Long roomId);
 }

--- a/src/main/java/refooding/api/domain/chat/service/RoomServiceImpl.java
+++ b/src/main/java/refooding/api/domain/chat/service/RoomServiceImpl.java
@@ -52,10 +52,10 @@ public class RoomServiceImpl implements RoomService {
         }
 
         // 채팅에 다른 회원을 초대한 회원(inviter)과 채팅에 초대된 회원(receiver) 조회
-        Member inviter = memberRepository.findById(inviterId)
+        Member inviter = memberRepository.findByIdAndDeletedDateIsNull(inviterId)
                 // TODO : 에러처리
                 .orElseThrow(() -> new CustomException(ExceptionCode.INTERNAL_SERVER_ERROR));
-        Member receiver = memberRepository.findById(receiverId)
+        Member receiver = memberRepository.findByIdAndDeletedDateIsNull(receiverId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_MEMBER));
 
         List<Long> memberIds = new ArrayList<>();
@@ -70,7 +70,11 @@ public class RoomServiceImpl implements RoomService {
         // TODO : 회원 도메인 구현시 적용
         // 임시 회원 아이디
         Long memberId = 1L;
-        List<Long> joinedRoomsIds = roomMemberRepository.findAllJoinedRoomsByMemberId(memberId)
+        Member findMember = memberRepository.findByIdAndDeletedDateIsNull(memberId)
+                // TODO : 에러처리
+                .orElseThrow(() -> new CustomException(ExceptionCode.INTERNAL_SERVER_ERROR));
+
+        List<Long> joinedRoomsIds = roomMemberRepository.findAllJoinedRoomsByMemberId(findMember.getId())
                 .stream()
                 .map(roomMember -> roomMember.getRoom().getId())
                 .toList();

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepository.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.domain.Slice;
 import refooding.api.domain.exchange.dto.response.ExchangeResponse;
 
 public interface ExchangeCustomRepository {
-    Slice<ExchangeResponse> findExchangeByCondition(ExchangeSearchCondition request, Pageable pageable);
+    Slice<ExchangeResponse> findExchangesByCondition(ExchangeSearchCondition request, Pageable pageable);
 }

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepositoryImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeCustomRepositoryImpl.java
@@ -25,7 +25,7 @@ public class ExchangeCustomRepositoryImpl implements ExchangeCustomRepository{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<ExchangeResponse> findExchangeByCondition(ExchangeSearchCondition condition, Pageable pageable) {
+    public Slice<ExchangeResponse> findExchangesByCondition(ExchangeSearchCondition condition, Pageable pageable) {
 
         QRegion parentRegion = new QRegion("parent");
 

--- a/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
@@ -104,7 +104,7 @@ public class ExchangeServiceImpl implements ExchangeService{
     }
 
     private Member getMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdAndDeletedDateIsNull(memberId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_MEMBER));
     }
 

--- a/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
@@ -31,7 +31,7 @@ public class ExchangeServiceImpl implements ExchangeService{
 
     @Override
     public Slice<ExchangeResponse> getExchanges(String keyword, ExchangeStatus status, Long regionId, Long lastExchangeId, Pageable pageable) {
-        return exchangeRepository.findExchangeByCondition(
+        return exchangeRepository.findExchangesByCondition(
                 new ExchangeSearchCondition(keyword, status, regionId, lastExchangeId),
                 pageable
         );


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- 채팅방 나가기 구현
- 채팅 목록 데이터에 마지막 메시지 읽음 여부 추가
 - 프론트에서 마지막 메시지 읽음 여부로 읽지않은 채팅방 표시 할 수 있음

## 💁‍♂️ 이슈

## 🔀 변경사항
- 삭제 날짜 필터링 : [[feat] 삭제 데이터 체크 로직 추가](https://github.com/HomeChefHub/refooding-be/commit/9c40704be34601d2ca14a7348e6e459431ee305f) https://github.com/HomeChefHub/refooding-be/issues/38 
- 메서드명, 변수명 변경 : [refactor] 메서드명, 변수명 변경 및 불필요한 코드 제거](https://github.com/HomeChefHub/refooding-be/commit/5be04258fd06f541a8854137bca9ed81485b0878) https://github.com/HomeChefHub/refooding-be/issues/38, 
[[fix] 식재료 교환 Repository 조회 메서드명 변경](https://github.com/HomeChefHub/refooding-be/commit/40944159d0228f5db7a783abb75dc037caf99663) https://github.com/HomeChefHub/refooding-be/issues/38

## 🔗 이슈번호
#38 

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
