### PR TITLE
[fix] 냉장고 재료 목록 조회시 id도 반환하도록 수정

### DIFF
--- a/src/main/java/refooding/api/domain/refrigerator/dto/MemberIngredientResponse.java
+++ b/src/main/java/refooding/api/domain/refrigerator/dto/MemberIngredientResponse.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class MemberIngredientResponse {
+    private Long id;
     private String name;
     private LocalDateTime startDate;
     private LocalDateTime endDate;

--- a/src/main/java/refooding/api/domain/refrigerator/service/MemberIngredientService.java
+++ b/src/main/java/refooding/api/domain/refrigerator/service/MemberIngredientService.java
@@ -111,6 +111,7 @@ public class MemberIngredientService {
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_MEMBER));
         return memberIngredientRepository.findByMemberIdWithIngredients(memberId).stream()
                 .map(mi -> MemberIngredientResponse.builder()
+                        .id(mi.getId())
                         .name(mi.getIngredient().getName())
                         .startDate(mi.getStartDate())
                         .endDate(mi.getEndDate())


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
냉장고 재료 목록 조회시 id도 반환하도록 수정

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항
냉장고 재료 목록 조회시 id도 반환하도록 수정

## 🔗 이슈번호

#61

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
