### PR TITLE
[feat] 레시피 상세조회 응답 데이터 매뉴얼 리스트 정렬 및 seq 데이터 제거

### DIFF
--- a/src/main/java/refooding/api/domain/recipe/dto/response/ManualResponse.java
+++ b/src/main/java/refooding/api/domain/recipe/dto/response/ManualResponse.java
@@ -3,8 +3,6 @@ package refooding.api.domain.recipe.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ManualResponse (
-    @Schema(description = "레시피 순서")
-    int seq,
     @Schema(description = "내용")
     String content
 ){}

--- a/src/main/java/refooding/api/domain/recipe/dto/response/RecipeDetailResponse.java
+++ b/src/main/java/refooding/api/domain/recipe/dto/response/RecipeDetailResponse.java
@@ -1,8 +1,10 @@
 package refooding.api.domain.recipe.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import refooding.api.domain.recipe.entity.Manual;
 import refooding.api.domain.recipe.entity.Recipe;
 
+import java.util.Comparator;
 import java.util.List;
 
 
@@ -23,7 +25,8 @@ public record RecipeDetailResponse (
     public static RecipeDetailResponse from(Recipe recipe) {
         List<ManualResponse> manualResponses = recipe.getManuals()
                 .stream()
-                .map(manual -> new ManualResponse(manual.getSeq(), manual.getContent()))
+                .sorted(Comparator.comparing(Manual::getSeq))
+                .map(manual -> new ManualResponse(manual.getContent()))
                 .toList();
         return new RecipeDetailResponse(
                 recipe.getId(),


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- 레시피 상세조회 응답 데이터 매뉴얼 리스트 정렬 및 seq 데이터 제거

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항
- 레시피 상세조회 응답 데이터 매뉴얼 리스트 정렬 및 seq 데이터 제거

## 🔗 이슈번호
#79 

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
