### PR TITLE
[feat] 식재료 수정 API 이미지 업데이트 구현

### DIFF
--- a/src/main/java/refooding/api/common/exception/ExceptionCode.java
+++ b/src/main/java/refooding/api/common/exception/ExceptionCode.java
@@ -11,6 +11,8 @@ public enum ExceptionCode {
     BLANK_FILE_NAME(HttpStatus.BAD_REQUEST, "파일 이름은 비어있을 수 없습니다"),
     INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "잘못된 파일 형식입니다"),
     UNSUPPORTED_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지않는 파일 확장자입니다"),
+    MAX_IMAGE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "최대 업로드 이미지 수를 초과했습니다"),
+    INVALID_S3_URL(HttpStatus.BAD_REQUEST, "S3 URL 형식이 올바르지 않습니다"),
 
     // 401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다"),
@@ -26,7 +28,7 @@ public enum ExceptionCode {
     // 500
     FILE_CONVERSION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 변환중 오류가 발생했습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다"),
-    TEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "테스트 에러입니");
+    TEST_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "테스트 에러입니다");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/refooding/api/domain/exchange/controller/ExchangeController.java
+++ b/src/main/java/refooding/api/domain/exchange/controller/ExchangeController.java
@@ -2,10 +2,12 @@ package refooding.api.domain.exchange.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
 import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
 import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;
@@ -18,6 +20,7 @@ import refooding.api.domain.exchange.service.RegionService;
 import java.net.URI;
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/exchanges")
 @RequiredArgsConstructor
@@ -48,18 +51,23 @@ public class ExchangeController implements ExchangeControllerOpenApi{
 
     @Override
     @PostMapping
-    public ResponseEntity<Void> create(@Valid @ModelAttribute ExchangeCreateRequest request) {
+    public ResponseEntity<Void> create(@ModelAttribute @Valid ExchangeCreateRequest request) {
         // TODO : 인증 추가
+        // 임시 회원 아이디
+        Long memberId = 1L;
 
-        Long exchangeId = exchangeService.create(request);
+        Long exchangeId = exchangeService.create(memberId, request);
         return ResponseEntity.created(URI.create("/api/v1/exchanges/" + exchangeId)).build();
     }
 
     @Override
     @PatchMapping("/{exchangeId}")
-    public ResponseEntity<Void> update(@PathVariable Long exchangeId, @Valid @RequestBody ExchangeUpdateRequest request){
+    public ResponseEntity<Void> update(@PathVariable Long exchangeId, @ModelAttribute @Valid ExchangeUpdateRequest request){
         // TODO : 인증 추가
-        exchangeService.update(exchangeId, request);
+        // 임시 회원 아이디
+        Long memberId = 1L;
+
+        exchangeService.update(memberId, exchangeId, request);
         return ResponseEntity.ok().build();
     }
 
@@ -67,7 +75,10 @@ public class ExchangeController implements ExchangeControllerOpenApi{
     @DeleteMapping("/{exchangeId}")
     public ResponseEntity<Void> delete(@PathVariable Long exchangeId) {
         // TODO : 인증 추가
-        exchangeService.delete(exchangeId);
+        // 임시 회원 아이디
+        Long memberId = 1L;
+
+        exchangeService.delete(memberId, exchangeId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/refooding/api/domain/exchange/controller/ExchangeControllerOpenApi.java
+++ b/src/main/java/refooding/api/domain/exchange/controller/ExchangeControllerOpenApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
 import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
 import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;

--- a/src/main/java/refooding/api/domain/exchange/dto/request/ExchangeCreateRequest.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/request/ExchangeCreateRequest.java
@@ -27,10 +27,8 @@ public record ExchangeCreateRequest(
         @Schema(description = "하위 지역 아이디")
         Long regionId,
 
-        @Size(max = 5, message = "이미지는 최대 5개까지 첨부할 수 있습니다")
-        @Schema(description = "식재료 이미지 파일")
-        List<MultipartFile> exchangeImageFiles
-
+        @Schema(description = "식재료 이미지")
+        MultipartFile image
 ) {
     public Exchange toExchange(Region region, Member member, List<ExchangeImage> images) {
         return new Exchange(title, content, region, member, images);

--- a/src/main/java/refooding/api/domain/exchange/dto/request/ExchangeUpdateRequest.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/request/ExchangeUpdateRequest.java
@@ -4,7 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import org.springframework.web.multipart.MultipartFile;
 import refooding.api.domain.exchange.entity.ExchangeStatus;
+
+import java.util.List;
 
 public record ExchangeUpdateRequest(
         @NotBlank(message = "제목은 빈 문자열 또는 null일 수 없습니다")
@@ -23,5 +26,11 @@ public record ExchangeUpdateRequest(
 
         @NotNull(message = "교환 상태를 입력해주세요")
         @Schema(description = "교환 상태")
-        ExchangeStatus status
+        ExchangeStatus status,
+
+        @Schema(description = "이미지 목록")
+        List<String> imageUrls,
+
+        @Schema(description = "식재료 이미지")
+        MultipartFile image
 ) {}

--- a/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeDetailResponse.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeDetailResponse.java
@@ -40,10 +40,7 @@ public record ExchangeDetailResponse(
         List<String> imageUrls
 
 ) {
-    public static ExchangeDetailResponse from(Exchange exchange) {
-        List<String> imageUrls = exchange.getImages().stream()
-                .map(ExchangeImage::getUrl)
-                .toList();
+    public static ExchangeDetailResponse from(Exchange exchange, List<String> imageUrls) {
         return new ExchangeDetailResponse(
                 exchange.getId(),
                 exchange.getTitle(),

--- a/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeResponse.java
+++ b/src/main/java/refooding/api/domain/exchange/dto/response/ExchangeResponse.java
@@ -31,7 +31,7 @@ public record ExchangeResponse(
         @Schema(description = "생성 시간")
         LocalDateTime createDate,
 
-        @Schema(description = "대표 미지")
+        @Schema(description = "대표 이미지")
         String thumbnailUrl
         // TODO : 회원
 ) {

--- a/src/main/java/refooding/api/domain/exchange/entity/Exchange.java
+++ b/src/main/java/refooding/api/domain/exchange/entity/Exchange.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import refooding.api.common.domain.BaseTimeEntity;
 import refooding.api.domain.member.entity.Member;
 
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -50,8 +52,8 @@ public class Exchange extends BaseTimeEntity {
         this.status = ExchangeStatus.ACTIVE;
         this.region = region;
         this.member = member;
-        this.images.addAll(images);
-        this.thumbnailUrl = !images.isEmpty() ? images.get(0).getUrl() : null;
+        this.images = images;
+        this.thumbnailUrl = getThumbnailUrl(images);
     }
 
     public void updateExchange(String title, String content, ExchangeStatus status, Region region) {
@@ -61,11 +63,22 @@ public class Exchange extends BaseTimeEntity {
         this.region = region;
     }
 
+    public void updateImages(List<ExchangeImage> newImages) {
+        this.images.addAll(newImages);
+        this.thumbnailUrl = getThumbnailUrl(newImages);
+        newImages.forEach(image -> image.setExchange(this));
+    }
+
     public void delete(){
         this.deletedDate = LocalDateTime.now();
     }
 
-    public boolean validateMember(Long memberId) {
-        return getMember().getId().equals(memberId);
+    public boolean isAuthor(Member member) {
+        return this.member.equals(member);
     }
+
+    private static String getThumbnailUrl(List<ExchangeImage> images) {
+        return images.isEmpty() ? null : images.get(0).getUrl();
+    }
+
 }

--- a/src/main/java/refooding/api/domain/exchange/entity/ExchangeImage.java
+++ b/src/main/java/refooding/api/domain/exchange/entity/ExchangeImage.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import refooding.api.common.domain.BaseTimeEntity;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -34,4 +36,7 @@ public class ExchangeImage extends BaseTimeEntity {
         this.exchange = exchange;
     }
 
+    public void delete() {
+        this.deletedDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeImageRepository.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeImageRepository.java
@@ -1,7 +1,15 @@
 package refooding.api.domain.exchange.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import refooding.api.domain.exchange.entity.ExchangeImage;
 
+import java.util.List;
+
 public interface ExchangeImageRepository extends JpaRepository<ExchangeImage, Long>, ExchangeImageCustomRepository {
+
+    @Query("select i from ExchangeImage i " +
+            "where i.exchange.id = :exchangeId " +
+            "and i.deletedDate is null")
+    List<ExchangeImage> findAllByExchangeId(Long exchangeId);
 }

--- a/src/main/java/refooding/api/domain/exchange/repository/ExchangeRepository.java
+++ b/src/main/java/refooding/api/domain/exchange/repository/ExchangeRepository.java
@@ -10,9 +10,9 @@ public interface ExchangeRepository extends JpaRepository<Exchange, Long>, Excha
 
     @Query("select e from Exchange e " +
             "join fetch e.member m " +
-            "left join fetch e.images i " +
             "join fetch e.region r " +
             "join fetch r.parent pr " +
-            "where e.id = :exchangeId and e.deletedDate is null")
+            "where e.id = :exchangeId " +
+            "and e.deletedDate is null")
     Optional<Exchange> findExchangeById(Long exchangeId);
 }

--- a/src/main/java/refooding/api/domain/exchange/service/ExchangeService.java
+++ b/src/main/java/refooding/api/domain/exchange/service/ExchangeService.java
@@ -14,10 +14,10 @@ public interface ExchangeService {
 
     ExchangeDetailResponse getExchangeById(Long exchangeId);
 
-    Long create(ExchangeCreateRequest request);
+    Long create(Long memberId, ExchangeCreateRequest request);
 
-    void update(Long exchangeId, ExchangeUpdateRequest request);
+    void update(Long memberId, Long exchangeId, ExchangeUpdateRequest request);
 
-    void delete(Long exchangeId);
+    void delete(Long memberId, Long exchangeId);
 
 }

--- a/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
+++ b/src/main/java/refooding/api/domain/exchange/service/ExchangeServiceImpl.java
@@ -1,14 +1,15 @@
 package refooding.api.domain.exchange.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import refooding.api.common.aws.S3Uploader;
 import refooding.api.common.exception.CustomException;
 import refooding.api.common.exception.ExceptionCode;
+import refooding.api.common.s3.S3Uploader;
 import refooding.api.domain.exchange.dto.request.ExchangeCreateRequest;
 import refooding.api.domain.exchange.dto.request.ExchangeUpdateRequest;
 import refooding.api.domain.exchange.dto.response.ExchangeDetailResponse;
@@ -24,9 +25,10 @@ import refooding.api.domain.exchange.repository.RegionRepository;
 import refooding.api.domain.member.entity.Member;
 import refooding.api.domain.member.repository.MemberRepository;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -48,89 +50,90 @@ public class ExchangeServiceImpl implements ExchangeService{
 
     @Override
     public ExchangeDetailResponse getExchangeById(Long exchangeId) {
-        Exchange exchange = getById(exchangeId);
-        return ExchangeDetailResponse.from(exchange);
+        Exchange findExchange = getById(exchangeId);
+        List<ExchangeImage> findImages = getImageByExchangeId(findExchange.getId());
+        List<String> imageUrls = findImages.stream()
+                .map(ExchangeImage::getUrl)
+                .toList();
+        return ExchangeDetailResponse.from(findExchange, imageUrls);
     }
 
     @Override
     @Transactional
-    public Long create(ExchangeCreateRequest request) {
-        // TODO : 회원 도메인 구현시 적용
-        // 임시 회원 아이디
-        Long memberId = 1L;
+    public Long create(Long memberId, ExchangeCreateRequest request) {
         Member findMember = getMemberById(memberId);
         Region region = getRegionById(request.regionId());
 
-        List<MultipartFile> imageFiles = request.exchangeImageFiles();
-        List<ExchangeImage> images = new ArrayList<>();
+        // S3 이미지 업로드
+        List<ExchangeImage> exchangeImages = uploadExchangeImages(request.image());
 
-        boolean isFileEmpty = isFileListNonEmpty(imageFiles);
-
-        if (!isFileEmpty) {
-            List<String> exchangeImageUrls = s3Uploader.uploadExchangeImg(imageFiles);
-            images = exchangeImageUrls.stream()
-                    .map(ExchangeImage::new)
-                    .toList();
-        }
-
-        Exchange exchange = request.toExchange(region, findMember, images);
+        Exchange exchange = request.toExchange(region, findMember, exchangeImages);
         Exchange savedExchange = exchangeRepository.save(exchange);
-
-        if (!isFileEmpty) {
-            images.forEach(image -> image.setExchange(savedExchange));
-            exchangeImageRepository.saveAll(images);
-        }
+        saveExchangeImages(savedExchange, exchangeImages);
 
         return savedExchange.getId();
     }
 
-    private static boolean isFileListNonEmpty(List<MultipartFile> imageFiles) {
-        return imageFiles == null || imageFiles.isEmpty();
-    }
-
-    private List<ExchangeImage> createExchangeImage(List<String> exchangeImageUrls) {
-        return exchangeImageUrls.stream()
-                .map(ExchangeImage::new)
-                .toList();
-    }
-
-
     @Override
     @Transactional
-    public void update(Long exchangeId, ExchangeUpdateRequest request) {
-        // TODO : 회원 도메인 구현시 적용
-        // 임시 회원 아이디
-        Long memberId = 1L;
+    public void update(Long memberId, Long exchangeId, ExchangeUpdateRequest request) {
         Member findMember = getMemberById(memberId);
-
-        Exchange exchange = getById(exchangeId);
-        if (!exchange.validateMember(findMember.getId())) {
-            throw new CustomException(ExceptionCode.UNAUTHORIZED);
-        }
+        Exchange findExchange = getById(exchangeId);
+        validateAuthor(findMember, findExchange);
         Region region = getRegionById(request.regionId());
 
-        exchange.updateExchange(
-                request.title(),
-                request.content(),
-                request.status(),
-                region
-        );
+        findExchange.updateExchange(request.title(), request.content(), request.status(), region);
+        updateExchangeImages(findExchange, request);
     }
 
     @Override
     @Transactional
-    public void delete(Long exchangeId) {
-        // TODO : 회원 도메인 구현시 적용
-        // 임시 회원 아이디
-        Long memberId = 1L;
+    public void delete(Long memberId, Long exchangeId) {
         Member findMember = getMemberById(memberId);
+        Exchange findExchange = getById(exchangeId);
+        validateAuthor(findMember, findExchange);
 
-        Exchange exchange = getById(exchangeId);
-        if (!exchange.validateMember(findMember.getId())) {
-            throw new CustomException(ExceptionCode.UNAUTHORIZED);
+        deleteOldImages(findExchange.getId());
+        findExchange.delete();
+    }
+
+    private List<ExchangeImage> uploadExchangeImages(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            return Collections.emptyList();
+        }
+        String imageUrl = s3Uploader.uploadExchangeImage(image);
+        return Collections.singletonList(new ExchangeImage(imageUrl));
+    }
+
+    private void updateExchangeImages(Exchange exchange, ExchangeUpdateRequest request) {
+        List<ExchangeImage> newImages = uploadExchangeImages(request.image());
+        boolean isNullOrEmpty = request.imageUrls() == null || request.imageUrls().isEmpty();
+
+        // 기존 이미지가 없으면서, 새로운 이미지 없으면 모든 이미지 삭제
+        if (isNullOrEmpty && newImages.isEmpty()) {
+            deleteOldImages(exchange.getId());
+            exchange.updateImages(newImages);
+            return;
         }
 
-        exchange.delete();
+        // 새로운 이미지가 있으면 기존 이미지 삭제 후 새로운 이미지 저장
+        if (!newImages.isEmpty()) {
+            deleteOldImages(exchange.getId());
+            saveExchangeImages(exchange, newImages);
+            exchange.updateImages(newImages);
+        }
+    }
+
+    private void saveExchangeImages(Exchange exchange, List<ExchangeImage> images) {
+        images.forEach(image -> {
+            image.setExchange(exchange);
+            exchangeImageRepository.save(image);
+        });
+    }
+
+    private void deleteOldImages(Long exchangeId) {
+        List<ExchangeImage> oldImages = getImageByExchangeId(exchangeId);
+        oldImages.forEach(ExchangeImage::delete);
     }
 
     private Exchange getById(Long exchangeId) {
@@ -147,4 +150,15 @@ public class ExchangeServiceImpl implements ExchangeService{
         return regionRepository.findById(regionId)
                 .orElseThrow(() -> new CustomException(ExceptionCode.NOT_FOUND_REGION));
     }
+
+    private List<ExchangeImage> getImageByExchangeId(Long exchangeId) {
+        return exchangeImageRepository.findAllByExchangeId(exchangeId);
+    }
+
+    private void validateAuthor(Member member, Exchange exchange) {
+        if (!exchange.isAuthor(member)) {
+            throw new CustomException(ExceptionCode.UNAUTHORIZED);
+        }
+    }
+
 }


### PR DESCRIPTION
> PR 당 코드의 변경은 300줄이 넘어가지 않도록 노력하기

## 📝 요약
- 식재료 수정 API 이미지 업데이트 구현

## 💁‍♂️ 이슈
(진행중 발생한 이슈가 있다면 작성)


## 🔀 변경사항
- 이미지 여러장 업로드 -> 단건 업로드 변경으로 이미지 요청 데이터 List -> MultipartFile 변경
- S3Uploader 단건 업로드 메서드 추가

## 🔗 이슈번호
#67 

---

<details open> <summary>스크린샷 & 비디오 </summary>

</details>
